### PR TITLE
[FIX] Message Entity와 관련 객체 그래프 탐색 코드 제거

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/domain/ChatRoom.java
+++ b/src/main/java/com/umc/yeongkkeul/domain/ChatRoom.java
@@ -19,6 +19,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class ChatRoom extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -66,6 +67,9 @@ public class ChatRoom extends BaseEntity {
     @OneToMany(mappedBy = "chatroom", cascade = CascadeType.ALL)
     private List<ChatRoomMembership> chatRoomMembershipList = new ArrayList<>();
 
+    /*
     @OneToMany(mappedBy = "chatroom", cascade = CascadeType.ALL)
     private List<Message> messageList = new ArrayList<>();
+
+     */
 }

--- a/src/main/java/com/umc/yeongkkeul/domain/Message.java
+++ b/src/main/java/com/umc/yeongkkeul/domain/Message.java
@@ -1,3 +1,4 @@
+/*
 package com.umc.yeongkkeul.domain;
 
 import com.umc.yeongkkeul.domain.common.BaseEntity;
@@ -36,3 +37,4 @@ public class Message extends BaseEntity {
     @Column(name = "image_url")
     private String imageUrl;
 }
+*/

--- a/src/main/java/com/umc/yeongkkeul/domain/User.java
+++ b/src/main/java/com/umc/yeongkkeul/domain/User.java
@@ -86,8 +86,11 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<ChatRoomMembership> chatRoomMembershipList = new ArrayList<>();
 
+    /*
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Message> messageList = new ArrayList<>();
+
+     */
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserTerms> userTermList = new ArrayList<>();


### PR DESCRIPTION
## #️⃣ 연관된 이슈
22-fix-채팅-entity-수정

## 📝 작업 내용
- Message와 같이 채팅 내역과 관련된 데이터를 Redis에 저장할 계획이기에 주석 처리했습니다.
- Message와 관련된 코드(객체 그래프 탐색)도 주석 처리 했습니다.
- 추후에 Redis에 저장하기 위한 dto record를 추가할 계획입니다.
