### PR TITLE
fix: Email을 userId로 바꾸는 로직 추가 #40

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/security/FindLoginUser.java
+++ b/src/main/java/com/umc/yeongkkeul/security/FindLoginUser.java
@@ -1,5 +1,7 @@
 package com.umc.yeongkkeul.security;
 
+import com.umc.yeongkkeul.apiPayload.code.status.ErrorStatus;
+import com.umc.yeongkkeul.apiPayload.exception.handler.UserHandler;
 import com.umc.yeongkkeul.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
@@ -28,4 +30,10 @@ public class FindLoginUser {
         }
         return null;
     }
+
+    public static Long toId(String email){
+        return userRepository.findByEmail(email).orElseThrow(()->new UserHandler(ErrorStatus.USER_NOT_FOUND)).getId();
+    }
+
+
 }

--- a/src/main/java/com/umc/yeongkkeul/web/controller/CategoryController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/CategoryController.java
@@ -14,6 +14,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
+import static com.umc.yeongkkeul.security.FindLoginUser.getCurrentUserId;
+import static com.umc.yeongkkeul.security.FindLoginUser.toId;
+
 @RestController
 @RequestMapping("/api/category")
 @Tag(name = "카테고리 API", description = "카테고리 관련 API 입니다.")
@@ -27,10 +30,10 @@ public class CategoryController {
     @PostMapping
     @Operation(summary = "카테고리 생성", description = "컬러값과 이름을 받아서, 카테고리 생성합니다.")
     public ApiResponse<CategoryResponseDTO.CategoryViewDTO> createCategory(
-            @RequestBody @Valid CategoryRequestDTO.CategoryDTO request,
-            Principal principal
+            @RequestBody @Valid CategoryRequestDTO.CategoryDTO request
     ) {
-        Long userId = Long.parseLong(principal.getName());
+        Long userId = toId(getCurrentUserId());
+
 
         CategoryResponseDTO.CategoryViewDTO response = categoryCommandService.addCategory(request, userId);
         return ApiResponse.onSuccess(response);
@@ -40,10 +43,9 @@ public class CategoryController {
     @Operation(summary = "카테고리 수정", description = "컬러값과 이름을 받아서, 카테고리 수정합니다.")
     public ApiResponse<CategoryResponseDTO.CategoryViewDTO> updateCategory(
             @PathVariable Long categoryId,
-            @RequestBody @Valid CategoryRequestDTO.CategoryDTO request,
-            Principal principal
+            @RequestBody @Valid CategoryRequestDTO.CategoryDTO request
     ) {
-        Long userId = Long.parseLong(principal.getName());
+        Long userId = toId(getCurrentUserId());
 
         CategoryResponseDTO.CategoryViewDTO response = categoryCommandService.updateCategory(categoryId, request, userId);
         return ApiResponse.onSuccess(response);
@@ -53,10 +55,9 @@ public class CategoryController {
     @GetMapping("/{categoryId}")
     @Operation(summary = "카테고리 조회", description = "카테고리 id기반 세부 조회합니다.")
     public ApiResponse<CategoryResponseDTO.CategoryViewDTO> viewCategory(
-            @PathVariable Long categoryId,
-            Principal principal
+            @PathVariable Long categoryId
     ){
-        Long userId = Long.parseLong(principal.getName());
+        Long userId = toId(getCurrentUserId());
 
         CategoryResponseDTO.CategoryViewDTO response = categoryQueryService.viewCategory(categoryId, userId);
         return ApiResponse.onSuccess(response);
@@ -64,8 +65,8 @@ public class CategoryController {
 
     @GetMapping("/categories")
     @Operation(summary = "카테고리 목록조회", description = "카테고리 목록 조회합니다.")
-    public ApiResponse<CategoryResponseDTO.CategoryViewListDTO> viewCategories(Principal principal){
-        Long userId = Long.parseLong(principal.getName());
+    public ApiResponse<CategoryResponseDTO.CategoryViewListDTO> viewCategories(){
+        Long userId = toId(getCurrentUserId());
 
         CategoryResponseDTO.CategoryViewListDTO response = categoryQueryService.viewCategories(userId);
         return ApiResponse.onSuccess(response);
@@ -74,8 +75,8 @@ public class CategoryController {
 
     @DeleteMapping("/{categoryId}")
     @Operation(summary = "카테고리 삭제", description = "카테고리 id로 삭제")
-    public ApiResponse<?> deleteCategory(@PathVariable Long categoryId, Principal principal) {
-        Long userId = Long.parseLong(principal.getName());
+    public ApiResponse<?> deleteCategory(@PathVariable Long categoryId) {
+        Long userId = toId(getCurrentUserId());
 
         categoryCommandService.deleteCategory(categoryId, userId);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#40 

## 📝 작업 내용
- email 값을 반환하던 getCurrentUserId()의 값을 toId로 user의 Id로 리턴하도록 변환로직 추가
- getCurrentUserId()의 로직 자체를 수정하지 않은 이유는 해당 로직으로 이미 구현된 서비스가 존재

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->
Long userId = toId(getCurrentUserId()); -> userId 값

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
