### PR TITLE
feat: 리워드 발급 메서드 구현 #44

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/YeongkkeulApplication.java
+++ b/src/main/java/com/umc/yeongkkeul/YeongkkeulApplication.java
@@ -2,7 +2,9 @@ package com.umc.yeongkkeul;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class YeongkkeulApplication {
 

--- a/src/main/java/com/umc/yeongkkeul/domain/Reward.java
+++ b/src/main/java/com/umc/yeongkkeul/domain/Reward.java
@@ -1,7 +1,7 @@
 package com.umc.yeongkkeul.domain;
 
 import com.umc.yeongkkeul.domain.common.BaseEntity;
-import com.umc.yeongkkeul.domain.enums.ReasonCode;
+import com.umc.yeongkkeul.domain.enums.RewardType;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
@@ -25,8 +25,8 @@ public class Reward extends BaseEntity {
     private int amount;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "reason_code", nullable = false, length = 50)
-    private ReasonCode reasonCode;
+    @Column(name = "reward_type", nullable = false, length = 50)
+    private RewardType rewardType;
 
     @Column(name = "description", length = 255)
     private String description;

--- a/src/main/java/com/umc/yeongkkeul/domain/enums/RewardType.java
+++ b/src/main/java/com/umc/yeongkkeul/domain/enums/RewardType.java
@@ -1,6 +1,6 @@
 package com.umc.yeongkkeul.domain.enums;
 
-public enum ReasonCode {
+public enum RewardType {
     INDIVIDUAL,
     TEAM;
 }

--- a/src/main/java/com/umc/yeongkkeul/service/RewardCommandService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/RewardCommandService.java
@@ -1,0 +1,29 @@
+package com.umc.yeongkkeul.service;
+
+import com.umc.yeongkkeul.apiPayload.code.status.ErrorStatus;
+import com.umc.yeongkkeul.apiPayload.exception.handler.UserHandler;
+import com.umc.yeongkkeul.domain.Reward;
+import com.umc.yeongkkeul.domain.User;
+import com.umc.yeongkkeul.repository.RewardRepository;
+import com.umc.yeongkkeul.repository.UserRepository;
+import com.umc.yeongkkeul.web.dto.RewardRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RewardCommandService {
+
+    private final UserRepository userRepository;
+    private final RewardRepository rewardRepository;
+
+    public void saveReward(Long userId, RewardRequestDto rewardRequestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        Reward reward = rewardRequestDto.toEntity(user);
+        rewardRepository.save(reward);
+    }
+}

--- a/src/main/java/com/umc/yeongkkeul/web/dto/RewardRequestDto.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/RewardRequestDto.java
@@ -1,0 +1,27 @@
+package com.umc.yeongkkeul.web.dto;
+
+import com.umc.yeongkkeul.domain.Reward;
+import com.umc.yeongkkeul.domain.User;
+import com.umc.yeongkkeul.domain.enums.RewardType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RewardRequestDto {
+
+    private RewardType rewardType;
+    private String description;
+    private int amount;
+
+    public Reward toEntity(User user) {
+        return Reward.builder()
+                .user(user)
+                .rewardType(this.rewardType)
+                .description(this.description)
+                .amount(this.amount)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/yeongkkeul/web/dto/RewardResponseDto.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/RewardResponseDto.java
@@ -18,7 +18,7 @@ public class RewardResponseDto {
     public static RewardResponseDto from(Reward reward) {
         return RewardResponseDto.builder()
                 .datetime(reward.getCreatedAt())
-                .record("INDIVIDUAL".equals(reward.getReasonCode().toString()) ? "개인 목표 달성" : "TEAM".equals(reward.getReasonCode().toString()) ? "팀 목표 달성" : null)
+                .record("INDIVIDUAL".equals(reward.getRewardType().toString()) ? "개인 목표 달성" : "TEAM".equals(reward.getRewardType().toString()) ? "팀 목표 달성" : null)
                 .type(reward.getDescription())
                 .reward(reward.getAmount())
                 .build();


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#44 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 리워드 발급 메서드 구현
- createdAt 반영 위해 @EnableJpaAuditing 어노테이션 추가
- 이름 충돌해서 ReasonCode -> RewardType 변경

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
리워드 발급 기준에 맞게 넣어서 메소드 사용
```
RewardRequestDto rewardRequestDto = RewardRequestDto.builder
                .rewardType(RewardType.INDIVIDUAL)       
                .description("식비에서 연속 5일 무지출 달성")       
                .amount(10)        
                .build();

rewardCommandService.saveReward(userId, rewardRequestDto);
```
