### PR TITLE
feat: 마이페이지 api 수정 # 66

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/umc/yeongkkeul/aws/s3/AmazonS3Manager.java
@@ -41,8 +41,8 @@ public class AmazonS3Manager{
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
     }
 
-    public String generateUserProfileKeyName(Uuid uuid) {
-        return amazonConfig.getUserProfilePath() + '/' + uuid.getUuid();
+    public String generateUserProfileKeyName(Long userId) {
+        return amazonConfig.getUserProfilePath() + '/' + userId;
     }
 
     public String generateChatroomProfileKeyName(Uuid uuid) {

--- a/src/main/java/com/umc/yeongkkeul/converter/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/com/umc/yeongkkeul/converter/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,34 @@
+package com.umc.yeongkkeul.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    /**
+     * Converter for support http request with header Content-Type: multipart/form-data
+     */
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/java/com/umc/yeongkkeul/repository/RewardRepository.java
+++ b/src/main/java/com/umc/yeongkkeul/repository/RewardRepository.java
@@ -4,9 +4,10 @@ import com.umc.yeongkkeul.domain.Reward;
 import com.umc.yeongkkeul.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface RewardRepository extends JpaRepository<Reward, Long> {
 
-    List<Reward> findByUser(User user);
+    List<Reward> findByUserAndCreatedAtAfterOrderByCreatedAtDesc(User user, LocalDateTime startDay);
 }

--- a/src/main/java/com/umc/yeongkkeul/service/MyPageQueryService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/MyPageQueryService.java
@@ -47,8 +47,10 @@ public class MyPageQueryService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        double weeklyAchievementRate = caculateWeeklyAchievementRate(user); // weeklyAchievementRate 계산
-
+        Double weeklyAchievementRate = null;
+        if (user.getDayTargetExpenditure() != null) {
+            weeklyAchievementRate = caculateWeeklyAchievementRate(user); // weeklyAchievementRate 계산
+        }
         return MyPageInfoResponseDto.of(user, weeklyAchievementRate);
     }
 

--- a/src/main/java/com/umc/yeongkkeul/service/MyPageQueryService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/MyPageQueryService.java
@@ -17,9 +17,12 @@ import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -86,14 +89,11 @@ public class MyPageQueryService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
+        LocalDateTime startDay = LocalDateTime.now().minusDays(7); // 7일 전 날짜
+        List<Reward> rewards = rewardRepository.findByUserAndCreatedAtAfterOrderByCreatedAtDesc(user, startDay); // 일주일 내 데이터만 최신순으로 가져오기
 
-        List<Reward> rewards = rewardRepository.findByUser(user);
-        List<RewardResponseDto> rewardList = new ArrayList<>();
-        for (Reward reward : rewards) {
-            RewardResponseDto dto = RewardResponseDto.from(reward);
-            rewardList.add(dto);
-        }
-
-        return rewardList;
+        return rewards.stream()
+                .map(RewardResponseDto::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/umc/yeongkkeul/web/controller/MyPageController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/MyPageController.java
@@ -7,7 +7,9 @@ import com.umc.yeongkkeul.web.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -36,11 +38,13 @@ public class MyPageController {
         return ApiResponse.onSuccess(myPageQueryService.getUserInfo(userId));
     }
 
-    @Operation(summary = "프로필 수정", description = "프로필 사진 관련 수정 예정입니다")
-    @PatchMapping("/api/mypage")
-    public ApiResponse<MyPageInfoResponseDto> updateUserInfo(@RequestBody MyPageInfoRequestDto myPageInfoRequestDto) {
+    @Operation(summary = "프로필 수정", description = "multipart/form-data로 보내야 합니다")
+    @PatchMapping(value = "/api/mypage", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ApiResponse<MyPageInfoResponseDto> updateUserInfo(@RequestPart("myPageInfoRequestDto") MyPageInfoRequestDto myPageInfoRequestDto,
+                                                             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage) {
+
         Long userId = toId(getCurrentUserId());
-        return ApiResponse.onSuccess(myPageCommandService.updateUserInfo(userId, myPageInfoRequestDto));
+        return ApiResponse.onSuccess(myPageCommandService.updateUserInfo(userId, myPageInfoRequestDto, profileImage));
     }
 
     @Operation(summary = "리워드 목록 조회")

--- a/src/main/java/com/umc/yeongkkeul/web/controller/MyPageController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/MyPageController.java
@@ -54,6 +54,14 @@ public class MyPageController {
         return ApiResponse.onSuccess(myPageQueryService.getRewardList(userId));
     }
 
+    @Operation(summary = "하루 목표 지출액 수정")
+    @PatchMapping("/api/expenditures/target")
+    public ApiResponse<MyPageInfoResponseDto> updateDayTargetExpenditure(@RequestBody ExpenseRequestDTO.DayTargetExpenditureRequestDto dayTargetExpenditureRequestDto) {
+        Long userId = toId(getCurrentUserId());
+
+        return ApiResponse.onSuccess(myPageCommandService.updateDayTargetExpenditure(userId, dayTargetExpenditureRequestDto));
+    }
+
     @Operation(summary = "회원 탈퇴")
     @DeleteMapping("/api/auth/delete")
     public ApiResponse<String> deleteUser(@RequestBody UserExitRequestDto userExitRequestDto) {

--- a/src/main/java/com/umc/yeongkkeul/web/dto/MyPageInfoRequestDto.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/MyPageInfoRequestDto.java
@@ -12,5 +12,4 @@ public class MyPageInfoRequestDto {
     private String gender;
     private AgeGroup ageGroup;
     private Job job;
-    private String profileImageUrl;
 }

--- a/src/main/java/com/umc/yeongkkeul/web/dto/MyPageInfoResponseDto.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/MyPageInfoResponseDto.java
@@ -18,9 +18,9 @@ public class MyPageInfoResponseDto {
     private String profileImageUrl;
     private Integer dayTargetExpenditure;
     private int rewardBalance;
-    private double weeklyAchievementRate;
+    private Double weeklyAchievementRate;
 
-    public static MyPageInfoResponseDto of(User user, double weeklyAchievementRate) {
+    public static MyPageInfoResponseDto of(User user, Double weeklyAchievementRate) {
         return MyPageInfoResponseDto.builder()
                 .nickname(user.getNickname())
                 .gender(user.getGender())


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#66

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 프로필 사진 s3 통해 file로 받게 수정
  - swagger에서 multipart/form-data인식 못하는 문제 해결 위해 MultipartJackson2HttpMessageConverter 추가
- 리워드 목록 조회 수정  (최근 7일 최신순 정렬)
- 하루 목표 지출액 수정 api 구현 
  - 하루 목표 지출액 null일 때 weeklyAchievementRate도 null로 반환되도록 Double타입으로 변경

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->