### PR TITLE
feat: 채팅방 서랍 기능 api 구현

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/yeongkkeul/apiPayload/code/status/ErrorStatus.java
@@ -58,7 +58,10 @@ public enum ErrorStatus implements BaseErrorCode {
     _NOT_ENOUGH_REWARD(HttpStatus.BAD_REQUEST,"REWARD4001","보유 리워드 부족합니다."),
 
     //Item
-    _ITEM_NOT_FOUND(HttpStatus.NOT_FOUND,"ITEM4001", "현재 스킨이 존재하지 않습니다.");
+    _ITEM_NOT_FOUND(HttpStatus.NOT_FOUND,"ITEM4001", "현재 스킨이 존재하지 않습니다."),
+
+    // Chat 서랍
+    _CHAT_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATIMAGE4001", "채팅방 이미지를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/yeongkkeul/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/umc/yeongkkeul/aws/s3/AmazonS3Manager.java
@@ -3,6 +3,9 @@ package com.umc.yeongkkeul.aws.s3;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.amazonaws.util.IOUtils;
 import com.umc.yeongkkeul.config.AmazonConfig;
 import com.umc.yeongkkeul.domain.common.Uuid;
 import com.umc.yeongkkeul.repository.UuidRepository;
@@ -36,6 +39,18 @@ public class AmazonS3Manager{
         }
 
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+
+    // 다운로드 기능 추가: S3의 파일을 byte[]로 반환합니다.
+    public byte[] downloadFile(String keyName) {
+        try {
+            S3Object s3Object = amazonS3.getObject(amazonConfig.getBucket(), keyName);
+            S3ObjectInputStream inputStream = s3Object.getObjectContent();
+            return IOUtils.toByteArray(inputStream);
+        } catch (IOException e) {
+            log.error("Error downloading file from S3 with key {}: {}", keyName, e.getMessage());
+            throw new RuntimeException("Failed to download file from S3", e);
+        }
     }
 
     public String getFileUrl(String keyName) {

--- a/src/main/java/com/umc/yeongkkeul/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/umc/yeongkkeul/aws/s3/AmazonS3Manager.java
@@ -41,12 +41,17 @@ public class AmazonS3Manager{
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
     }
 
-    // 다운로드 기능 추가: S3의 파일을 byte[]로 반환합니다.
-    public byte[] downloadFile(String keyName) {
+    /**
+     * S3에서 파일을 다운로드하며, 파일 데이터와 함께 원본의 contentType를 반환합니다.
+     */
+    public S3DownloadResponse downloadFileWithMetadata(String keyName) {
         try {
             S3Object s3Object = amazonS3.getObject(amazonConfig.getBucket(), keyName);
             S3ObjectInputStream inputStream = s3Object.getObjectContent();
-            return IOUtils.toByteArray(inputStream);
+            byte[] data = IOUtils.toByteArray(inputStream);
+            // S3 객체의 메타데이터에서 콘텐츠 타입을 가져옵니다.
+            String contentType = s3Object.getObjectMetadata().getContentType();
+            return new S3DownloadResponse(data, contentType);
         } catch (IOException e) {
             log.error("Error downloading file from S3 with key {}: {}", keyName, e.getMessage());
             throw new RuntimeException("Failed to download file from S3", e);
@@ -71,5 +76,26 @@ public class AmazonS3Manager{
 
     public String generateChatKeyName(Uuid uuid) {
         return amazonConfig.getChatPath() + '/' + uuid.getUuid();
+    }
+
+    /**
+     * S3 다운로드 결과를 담는 DTO. -> 추후 다운로드 api에서 메타데이터 넣는 활용 필요해서 추가함
+     */
+    public static class S3DownloadResponse {
+        private final byte[] data;
+        private final String contentType;
+
+        public S3DownloadResponse(byte[] data, String contentType) {
+            this.data = data;
+            this.contentType = contentType;
+        }
+
+        public byte[] getData() {
+            return data;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
     }
 }

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
@@ -1,6 +1,7 @@
 package com.umc.yeongkkeul.web.controller;
 
 import com.umc.yeongkkeul.apiPayload.ApiResponse;
+import com.umc.yeongkkeul.aws.s3.AmazonS3Manager;
 import com.umc.yeongkkeul.service.ChatService;
 import com.umc.yeongkkeul.web.dto.chat.*;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,9 +9,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -108,5 +110,51 @@ public class ChatAPIController {
     public ApiResponse<ReceiptMessageDto> getReceiptDetail(@PathVariable Long expenseId) {
 
         return ApiResponse.onSuccess(chatService.getReceipt(expenseId));
+    }
+    /**
+     * 채팅방에 업로드된 이미지 목록 조회 API
+     * messageType이 "IMAGE"인 메시지의 S3 key를 활용해 이미지 URL을 생성합니다.
+     */
+    @GetMapping("/{chatRoomId}/images")
+    @Operation(summary = "채팅방 이미지 조회", description = "채팅방에 업로드된 이미지 목록(이미지 URL)을 조회합니다.")
+    public ApiResponse<List<String>> getChatRoomImages(@PathVariable Long chatRoomId) {
+        List<String> imageUrls = chatService.getChatRoomImageUrls(chatRoomId);
+        return ApiResponse.onSuccess(imageUrls);
+    }
+
+    /**
+     * 채팅방 이미지 다운로드 API
+     * 특정 이미지 메시지(messageId)에 대해, S3에서 파일 데이터를 다운로드한 후 원본 콘텐츠 타입에 맞게 응답 헤더를 설정합니다.
+     */
+    @GetMapping("/{chatRoomId}/images/{messageId}/download")
+    @Operation(summary = "채팅방 이미지 다운로드", description = "채팅방에 업로드된 이미지를 다운로드합니다.")
+    public ResponseEntity<byte[]> downloadChatImage(@PathVariable Long chatRoomId, @PathVariable Long messageId) {
+        AmazonS3Manager.S3DownloadResponse downloadResponse = chatService.downloadChatImage(chatRoomId, messageId);
+
+        HttpHeaders headers = new HttpHeaders();
+        // S3에 저장된 원본 콘텐츠 타입을 사용합니다.
+        headers.setContentType(MediaType.parseMediaType(downloadResponse.getContentType()));
+        headers.setContentLength(downloadResponse.getData().length);
+        headers.setContentDisposition(ContentDisposition.builder("attachment")
+                .filename("message_" + messageId)
+                .build());
+
+        return new ResponseEntity<>(downloadResponse.getData(), headers, HttpStatus.OK);
+    }
+
+    /**
+     * 채팅 이미지 업로드 API
+     * 클라이언트는 이미지를 업로드한 후, 반환된 이미지 URL을 포함하여 채팅 메시지를 전송할 수 있습니다.
+     *
+     * @param chatRoomId 채팅방 ID
+     * @param file 업로드할 이미지 파일 (Multipart 형식)
+     * @return S3에 저장된 이미지 URL
+     */
+    @PostMapping("/{chatRoomId}/images")
+    @Operation(summary = "채팅 이미지 업로드", description = "채팅 이미지를 S3에 업로드하고 이미지 URL을 반환합니다.")
+    public ApiResponse<String> uploadChatImage(@PathVariable Long chatRoomId,
+                                               @RequestParam("file") MultipartFile file) {
+        String imageUrl = chatService.uploadChatImage(chatRoomId, file);
+        return ApiResponse.onSuccess(imageUrl);
     }
 }

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatController.java
@@ -14,10 +14,8 @@ import org.springframework.amqp.AmqpException;
 import org.springframework.http.*;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -144,5 +142,21 @@ public class ChatController {
                 .build());
 
         return new ResponseEntity<>(downloadResponse.getData(), headers, HttpStatus.OK);
+    }
+
+    /**
+     * 채팅 이미지 업로드 API
+     * 클라이언트는 이미지를 업로드한 후, 반환된 이미지 URL을 포함하여 채팅 메시지를 전송할 수 있습니다.
+     *
+     * @param chatRoomId 채팅방 ID
+     * @param file 업로드할 이미지 파일 (Multipart 형식)
+     * @return S3에 저장된 이미지 URL
+     */
+    @PostMapping("/{chatRoomId}/images")
+    @Operation(summary = "채팅 이미지 업로드", description = "채팅 이미지를 S3에 업로드하고 이미지 URL을 반환합니다.")
+    public ApiResponse<String> uploadChatImage(@PathVariable Long chatRoomId,
+                                               @RequestParam("file") MultipartFile file) {
+        String imageUrl = chatService.uploadChatImage(chatRoomId, file);
+        return ApiResponse.onSuccess(imageUrl);
     }
 }

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatController.java
@@ -1,17 +1,24 @@
 package com.umc.yeongkkeul.web.controller;
 
+import com.umc.yeongkkeul.apiPayload.ApiResponse;
 import com.umc.yeongkkeul.apiPayload.code.status.ErrorStatus;
 import com.umc.yeongkkeul.apiPayload.exception.handler.ChatRoomHandler;
 import com.umc.yeongkkeul.service.ChatService;
 import com.umc.yeongkkeul.web.dto.chat.EnterMessageDto;
 import com.umc.yeongkkeul.web.dto.chat.MessageDto;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.AmqpException;
+import org.springframework.http.*;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 /**
  * ChatController 클래스
@@ -105,5 +112,27 @@ public class ChatController {
         chatService.exitMessage(exitMessageDto);
         log.info("The user with senderID has left the chat room.");
         chatService.saveMessages(exitMessageDto);
+    }
+
+    /**
+     * 채팅방에 업로드된 이미지 목록 조회 API
+     * 채팅 메시지 중 messageType이 "IMAGE"인 경우, content에 저장된 S3 key를 통해 이미지 URL을 생성합니다.
+     */
+    @GetMapping("/{chatRoomId}/images")
+    @Operation(summary = "채팅방 이미지 조회", description = "채팅방에 업로드된 이미지 목록(이미지 URL)을 조회합니다.")
+    public ApiResponse<List<String>> getChatRoomImages(@PathVariable Long chatRoomId) {
+
+        return ApiResponse.onSuccess(null);
+    }
+
+    /**
+     * 채팅방 이미지 다운로드 API
+     * 특정 채팅 메시지(messageId)가 이미지임을 확인한 후, S3에서 해당 파일을 읽어 byte[]로 반환합니다.
+     */
+    @GetMapping("/{chatRoomId}/images/{messageId}/download")
+    @Operation(summary = "채팅방 이미지 다운로드", description = "채팅방에 업로드된 이미지를 다운로드합니다.")
+    public ResponseEntity<byte[]> downloadChatImage(@PathVariable Long chatRoomId, @PathVariable Long messageId) {
+
+        return null;
     }
 }

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatController.java
@@ -113,50 +113,5 @@ public class ChatController {
         chatService.saveMessages(exitMessageDto);
     }
 
-    /**
-     * 채팅방에 업로드된 이미지 목록 조회 API
-     * messageType이 "IMAGE"인 메시지의 S3 key를 활용해 이미지 URL을 생성합니다.
-     */
-    @GetMapping("/{chatRoomId}/images")
-    @Operation(summary = "채팅방 이미지 조회", description = "채팅방에 업로드된 이미지 목록(이미지 URL)을 조회합니다.")
-    public ApiResponse<List<String>> getChatRoomImages(@PathVariable Long chatRoomId) {
-        List<String> imageUrls = chatService.getChatRoomImageUrls(chatRoomId);
-        return ApiResponse.onSuccess(imageUrls);
-    }
 
-    /**
-     * 채팅방 이미지 다운로드 API
-     * 특정 이미지 메시지(messageId)에 대해, S3에서 파일 데이터를 다운로드한 후 원본 콘텐츠 타입에 맞게 응답 헤더를 설정합니다.
-     */
-    @GetMapping("/{chatRoomId}/images/{messageId}/download")
-    @Operation(summary = "채팅방 이미지 다운로드", description = "채팅방에 업로드된 이미지를 다운로드합니다.")
-    public ResponseEntity<byte[]> downloadChatImage(@PathVariable Long chatRoomId, @PathVariable Long messageId) {
-        AmazonS3Manager.S3DownloadResponse downloadResponse = chatService.downloadChatImage(chatRoomId, messageId);
-
-        HttpHeaders headers = new HttpHeaders();
-        // S3에 저장된 원본 콘텐츠 타입을 사용합니다.
-        headers.setContentType(MediaType.parseMediaType(downloadResponse.getContentType()));
-        headers.setContentLength(downloadResponse.getData().length);
-        headers.setContentDisposition(ContentDisposition.builder("attachment")
-                .filename("message_" + messageId)
-                .build());
-
-        return new ResponseEntity<>(downloadResponse.getData(), headers, HttpStatus.OK);
-    }
-
-    /**
-     * 채팅 이미지 업로드 API
-     * 클라이언트는 이미지를 업로드한 후, 반환된 이미지 URL을 포함하여 채팅 메시지를 전송할 수 있습니다.
-     *
-     * @param chatRoomId 채팅방 ID
-     * @param file 업로드할 이미지 파일 (Multipart 형식)
-     * @return S3에 저장된 이미지 URL
-     */
-    @PostMapping("/{chatRoomId}/images")
-    @Operation(summary = "채팅 이미지 업로드", description = "채팅 이미지를 S3에 업로드하고 이미지 URL을 반환합니다.")
-    public ApiResponse<String> uploadChatImage(@PathVariable Long chatRoomId,
-                                               @RequestParam("file") MultipartFile file) {
-        String imageUrl = chatService.uploadChatImage(chatRoomId, file);
-        return ApiResponse.onSuccess(imageUrl);
-    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#63 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- S3 Manager에 다운로드 기능 추가 및 원본 데이터의 메타데이터 정보 저장
- 채팅 메시지를 Get하는 로직을 활용하여, 이미지 타입인 이미지 메시지들 조회(이미지 메시지의 content에는 s3 저장 필요)
- 이미지를 다운로드하는 API 추가하여, 원본데이터와 같은 ContentType으로 다운로드 가능 

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 프론트에서 이미지 업로드 api를 활용해, 이미지 업로드를 진행
- 업로드한 이미지의 S3 주소를 받아서, 채팅 메시지를 전송(타입을 이미지로 지정)
- 서랍기능을 위해 이미지 get으로 이미지 메시지만 조회
- 이미지 메시지 다운 api를 사용해 필요시, 다운