### PR TITLE
feat: 카테고리 삭제시, 종속된 지출 내역을 임시 카테고리에 보존하도록 로직변경

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/yeongkkeul/apiPayload/code/status/ErrorStatus.java
@@ -28,6 +28,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CATEGORY_DUPLICATE(HttpStatus.CONFLICT, "CATEGORY4004", "동일한 카테고리가 이미 존재합니다."),
     CATEGORY_NO_PERMISSION(HttpStatus.FORBIDDEN, "CATEGORY4002", "해당 카테고리에 대한 접근 권한이 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "CATEGORY4001", "카테고리를 찾을 수 없습니다."),
+    CANNOT_DELETE_TRASH_CATEGORY(HttpStatus.BAD_REQUEST, "CATEGORY4003", "임시 카테고리는 삭제할 수 없습니다."),
 
     //JWT
     _INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "USER4003", "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/umc/yeongkkeul/repository/CategoryRepository.java
+++ b/src/main/java/com/umc/yeongkkeul/repository/CategoryRepository.java
@@ -16,4 +16,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     List<Category> findAllByUserId(Long userId);
 
     Optional<Category> findById(Long id);
+
+    // 유저와 이름으로 카테고리 찾기
+    Optional<Category> findByUserAndName(User user, String name);
 }

--- a/src/main/java/com/umc/yeongkkeul/service/ExpenseCommandServiceImpl.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ExpenseCommandServiceImpl.java
@@ -50,6 +50,10 @@ public class ExpenseCommandServiceImpl extends ExpenseCommandService {
 
         Expense expense = ExpenseConverter.createExpense(request, user, category, request.getIsExpense());
 
+        // 양방향 연관관계의 일관성을 위해, 생성된 Expense를 Category의 expenseList에 추가
+        // 이렇게 설정해야 나중에 카테고리에서 get을 통해 지출을 가져올 수 있음.
+        category.getExpenseList().add(expense);
+
         // 유저의 지출 내역 저장
         return expenseRepository.save(expense);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#96 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 카테고리 삭제시, 종속된 지출 내역을 임시 카테고리에 보존하도록 로직변경
- 임시 카테고리 trash가 존재하는지 확인 후 없다면 생성(유저 내에서 이름이 고유하도록 개발해놔서 가능)
- 지우려던 카테고리의 지출 내역을 모두 유저의 trash에 이전
- 카테고리 삭제

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
민지님 양방향 연관관계 설정을 추가해서, 지출이 생성될 때 카테고리의 list안에 값을 추가하도록 변경했습니다~
