### PR TITLE
[FIX] 채팅 내역, 채팅방 정보 동기화(조회) 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,8 +73,8 @@ dependencies {
 	/* RabbitMQ */
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
-	/* TSID */
-	implementation 'com.github.f4b6a3:tsid-creator:5.4.0'
+	/* TSID Generator */
+	implementation 'com.github.f4b6a3:tsid-creator:5.2.6'
 
 	/* S3 */
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ dependencies {
 	/* RabbitMQ */
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
+	/* TSID */
+	implementation 'com.github.f4b6a3:tsid-creator:5.4.0'
+
 	/* S3 */
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 

--- a/src/main/java/com/umc/yeongkkeul/converter/ChatRoomConverter.java
+++ b/src/main/java/com/umc/yeongkkeul/converter/ChatRoomConverter.java
@@ -37,7 +37,7 @@ public class ChatRoomConverter {
      * @param chatRoom
      * @return 채팅방-사용자 테이블 저장을 위한 convert 메서드로 User와 ChatRoom 객체를 받아서 ChatRoomMembership Entity로 변환
      */
-    public static ChatRoomMembership toChatRoomMembershipEntity(User user, ChatRoom chatRoom, boolean isHost) {
+    public static ChatRoomMembership toChatRoomMembershipEntity(User user, ChatRoom chatRoom, boolean isHost, Long joinMessageId) {
 
         return ChatRoomMembership.builder()
                 .user(user)
@@ -45,6 +45,8 @@ public class ChatRoomConverter {
                 .isHost(isHost)
                 .isBanned(false)
                 .joinedAt(LocalDateTime.now())
+                .userScore((double) 0)
+                .joinMessageId(joinMessageId)
                 .build();
     }
 

--- a/src/main/java/com/umc/yeongkkeul/domain/mapping/ChatRoomMembership.java
+++ b/src/main/java/com/umc/yeongkkeul/domain/mapping/ChatRoomMembership.java
@@ -55,4 +55,7 @@ public class ChatRoomMembership extends BaseEntity {
     // 개인 점수 (랭킹용)
     @Column(name = "user_score")
     private Double userScore;
+
+    @Column(name = "join_message_id")
+    private Long joinMessageId;
 }

--- a/src/main/java/com/umc/yeongkkeul/repository/ChatRoomMembershipRepository.java
+++ b/src/main/java/com/umc/yeongkkeul/repository/ChatRoomMembershipRepository.java
@@ -16,8 +16,9 @@ public interface ChatRoomMembershipRepository extends JpaRepository<ChatRoomMemb
     @Query("SELECT c FROM ChatRoomMembership c WHERE c.chatroom.id = :chatRoomId ORDER BY c.userScore DESC")
     List<ChatRoomMembership> findByChatroomIdOrderByUserScoreDesc(@Param("chatRoomId") Long chatRoomId);
 
-
     Optional<ChatRoomMembership> findByUserIdAndChatroomId(Long userId, Long chatRoomId);
+
+    List<ChatRoomMembership> findAllByUserId(Long userId);
 
     @Modifying
     @Transactional

--- a/src/main/java/com/umc/yeongkkeul/repository/ChatRoomRepository.java
+++ b/src/main/java/com/umc/yeongkkeul/repository/ChatRoomRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     @Query("SELECT c FROM ChatRoom c " +
@@ -23,4 +25,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
                                          Pageable pageable);
 
     Page<ChatRoom> findByTitleContainingOrderByParticipationCountDesc(String title, Pageable pageable);
+
+    @Query("SELECT c FROM ChatRoom c WHERE c.id IN :chatRoomIds")
+    List<ChatRoom> findAllByIdIn(@Param("chatRoomIds") List<Long> chatRoomIds);
+
 }

--- a/src/main/java/com/umc/yeongkkeul/service/ChatService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ChatService.java
@@ -177,6 +177,12 @@ public class ChatService {
         return resultMessageList;
     }
 
+    /**
+     *
+     *
+     * @param userId
+     * @return
+     */
     public List<ChatRoomInfoResponseDto> synchronizationChatRoomsInfo(Long userId) {
 
         User user = userRepository.findById(userId)

--- a/src/main/java/com/umc/yeongkkeul/service/ChatService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ChatService.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -39,9 +40,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -108,7 +107,7 @@ public class ChatService {
     }
 
     /**
-     * 특정 채팅방의 모든 메시지를 조회.
+     * 특정 채팅방의 모든 메시지를 조회 - 테스트 용도.
      *
      * @param chatRoomId 조회할 채팅방 ID
      * @return List<MessageDto> 채팅방의 메시지 리스트
@@ -121,6 +120,61 @@ public class ChatService {
         return messgeList.stream()
                 .map(object -> (MessageDto) object)
                 .toList();
+    }
+
+    /**
+     * 특정 채팅방 클라이언트에서 업데이트 되지 않은 메시지를 조회
+     *
+     * @param userId
+     * @param chatRoomId
+     * @param lastClientMessageId
+     * @return
+     */
+    public List<MessageDto> synchronizationChatMessages(Long userId, Long chatRoomId, Long lastClientMessageId) {
+
+        List<MessageDto> resultMessageList = new ArrayList<>();
+
+        ChatRoomMembership chatRoomMembership = chatRoomMembershipRepository.findByUserIdAndChatroomId(userId, chatRoomId)
+                .orElseThrow();
+
+        // 채팅방 입장 메시지 ID
+        // 이전의 채팅 내역은 못본다.
+        Long joinServerMessageId = chatRoomMembership.getJoinMessageId();
+
+        String redisKey = "chat:room:" + chatRoomId + ":message";
+        ListOperations<String, Object> listOps = redisTemplate.opsForList();
+        long messageSize = listOps.size(redisKey);
+
+        // 30개씩 읽어오며, ID를 찾을 때까지 반복
+        final int REDIS_BATCH_SIZE = 30;
+        for (long start = 0; start < messageSize; start += REDIS_BATCH_SIZE) {
+
+            long end = start + REDIS_BATCH_SIZE - 1;
+            if (end >= messageSize) end = messageSize - 1;
+
+            List<Object> messgeList = redisTemplate.opsForList().range(redisKey, start, end);
+
+            // 읽어온 메시지들에서 lastClientMessageId를 포함하는 메시지 찾기
+            for (Object message : messgeList) {
+                if (message != null) {
+
+                    MessageDto messageDto = (MessageDto) message;
+                    resultMessageList.add(messageDto);
+
+                    // 최신 메시지일 수록 ID값이 커지고 현재 탐색한 메시지가 채팅방 입장 메시지보다 작다는 것은 채팅방 이전의 메시지를 본다는 것이기에 반환해준다.
+                    if (messageDto.id() < joinServerMessageId) return resultMessageList;
+
+                    if (Objects.equals(messageDto.id(), lastClientMessageId)) {
+                        return resultMessageList;
+                    }
+                } else {
+                    log.error("The Message is NULL.");
+                    return null;
+                }
+            }
+        }
+
+        return resultMessageList;
     }
 
     /**
@@ -171,7 +225,7 @@ public class ChatService {
         // 채팅방-사용자 저장
         // 방장이기에 isHost에 true값 설정
         boolean isHost = true;
-        ChatRoomMembership chatRoomMembership = ChatRoomConverter.toChatRoomMembershipEntity(user, savedChatRoom, isHost);
+        ChatRoomMembership chatRoomMembership = ChatRoomConverter.toChatRoomMembershipEntity(user, savedChatRoom, isHost, -1L);
         chatRoomMembershipRepository.save(chatRoomMembership);
 
         return savedChatRoom.getId();
@@ -188,7 +242,7 @@ public class ChatService {
 
         // 최근 활동을 확인하기 위해 Redis에서 가장 마지막에 저장된 List를 가져오는 로직
         String redisKey = "chat:room:" + chatRoomId + ":message";
-        Object lastMessageObject = redisTemplate.opsForList().index(redisKey, -1);
+        Object lastMessageObject = redisTemplate.opsForList().index(redisKey, 0);
 
         // redisKey가 존재하지 않거나 리스트가 비어 있으면 null 반환
         if (lastMessageObject != null) {
@@ -220,7 +274,7 @@ public class ChatService {
                 .orElseThrow(() -> new ChatRoomHandler(ErrorStatus._CHATROOM_NOT_FOUND));
 
         boolean isHost = false; // 호스트가 아니기에 false
-        ChatRoomMembership chatRoomMembership = ChatRoomConverter.toChatRoomMembershipEntity(user, chatRoom, isHost);
+        ChatRoomMembership chatRoomMembership = ChatRoomConverter.toChatRoomMembershipEntity(user, chatRoom, isHost, messageDto.id());
 
         // 채팅방-사용자 관계 테이블 저장
         chatRoomMembershipRepository.save(chatRoomMembership);
@@ -357,12 +411,12 @@ public class ChatService {
      * @param lastActivityTime 마지막 메시지를 보낸 시간
      * @return 마지막 활동 시간을 현재 시간과 비교하여 문자열로 반환
      */
-    private String convertToLastActivity(LocalDateTime lastActivityTime) {
+    private String convertToLastActivity(String lastActivityTime) {
 
         // lastActivityTime이 null이라면 메서드 종료
-        if (lastActivityTime == null) return null;
+        if (lastActivityTime == null || lastActivityTime.isEmpty()) return null;
 
-        long seconds = Duration.between(lastActivityTime, LocalDateTime.now()).getSeconds();
+        long seconds = Duration.between(LocalDateTime.parse(lastActivityTime), LocalDateTime.now()).getSeconds();
 
         if (seconds < 60) return seconds + "초 전 활동";
         if (seconds < 3600) return (seconds / 60) + "분 전 활동";

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
@@ -53,6 +53,7 @@ public class ChatAPIController {
 
     /**
      *
+     *
      * @param chatRoomId
      * @param lastClientMessageId 클라이언트에 저장된 마지막 메시지 ID
      * @return
@@ -66,6 +67,11 @@ public class ChatAPIController {
         return ApiResponse.onSuccess(chatService.synchronizationChatMessages(userId, chatRoomId, lastClientMessageId));
     }
 
+    /**
+     *
+     *
+     * @return
+     */
     @Operation(summary = "클라이언트와 서버의 채팅방 정보 조회", description = "웹소켓 연결이 끊어지면 클라이언트와 서버 간의 채팅방 정보가 일치 하지 않을 수 있기에 이 API를 호출해서 클라이언트가 서버의 데이터를 조회하도록 시켜줍니다.")
     @GetMapping
     public ApiResponse<List<ChatRoomInfoResponseDto>> synchronizationChatRoomsInfo() {

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
@@ -38,13 +38,10 @@ public class ChatAPIController {
      * @param chatRoomId  조회할 채팅방 ID
      * @return ResponseEntity<List<MessageDto>> 채팅 메시지 리스트
      *
-     * 주의: 이 메서드는 서버 DB에서 데이터를 반복적으로 가져오므로 성능 문제가 발생할 수 있음.
-     *       가능한 한 호출 횟수를 줄이는 방식으로 개선 필요.
+     * 주의: 이 API는 단순히 테스트 용도로 사용.
      */
-    // TODO: 로컬 DB와 서버 DB의 사용 여부에 따라 로직을 수정해야 한다.
-    // TODO: 로컬 DB에 저장한다고 해도 채팅방 상태가 바뀔 수도 있기 때문에 이를 지속적으로 추적하거나 요청해도 변경점을 찾아야 하는 로직이 필요하다.
-    @GetMapping("/{chatRoomId}")
-    @Operation(summary = "특정 채팅방 메시지 조회", description = "특정 채팅방의 모든 메시지를 조회합니다.")
+    @GetMapping("/{chatRoomId}/messages/test")
+    @Operation(summary = "특정 채팅방 메시지 조회 - 테스트 용도", description = "특정 채팅방의 모든 메시지를 조회합니다. 실제 환경에서 채팅방의 모든 메시지를 가져오는 것은 성능의 문제가 있으므로 테스트 용도로 사용합니다.")
     public ApiResponse<List<MessageDto>> getChatMessages(@PathVariable Long chatRoomId) {
 
         Long userId = toId(getCurrentUserId());
@@ -53,6 +50,25 @@ public class ChatAPIController {
 
         return ApiResponse.onSuccess(messageDtos);
     }
+
+    /**
+     *
+     * @param chatRoomId
+     * @param lastClientMessageId 클라이언트에 저장된 마지막 메시지 ID
+     * @return
+     */
+    @Operation(summary = "클라이언트와 서버의 메시지 동기화(조회)", description = "웹소켓이 재연결되거나 오류로 인해 메시지를 받지 못할 경우를 생각해서 특정 채팅방에 들어가면 항상 이 API를 호출합니다. 인터넷에 연결되지 않거나 다른 이유로 정상적인 응답을 받지 못하면 기존에 클라이언트에 저장되었던 정보를 화면에 유지합니다.")
+    @GetMapping("/{chatRoomId}/messages")
+    public ApiResponse<List<MessageDto>> synchronizationChatMessages(@PathVariable Long chatRoomId, @RequestParam("messageId") Long lastClientMessageId) {
+
+        // FIXME
+        Long userId = 1L;
+
+        return ApiResponse.onSuccess(chatService.synchronizationChatMessages(userId, chatRoomId, lastClientMessageId));
+    }
+
+    // TODO: 웹 소켓 연결이 끊어졌다가 재연결될 경우 특정 채팅방 조회
+    // TODO: 웹 소켓 연결이 끊어졌다가 재연결될 경우 모든 채팅방 조회
 
     /**
      * @param chatRoomDetailRequestDto 채팅방 생성 DTO

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
@@ -76,7 +76,7 @@ public class ChatAPIController {
     @GetMapping
     public ApiResponse<List<ChatRoomInfoResponseDto>> synchronizationChatRoomsInfo() {
 
-        Long userId = 1L; //toId(getCurrentUserId());
+        Long userId = toId(getCurrentUserId());
 
         return ApiResponse.onSuccess(chatService.synchronizationChatRoomsInfo(userId));
     }

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
@@ -61,14 +61,21 @@ public class ChatAPIController {
     @GetMapping("/{chatRoomId}/messages")
     public ApiResponse<List<MessageDto>> synchronizationChatMessages(@PathVariable Long chatRoomId, @RequestParam("messageId") Long lastClientMessageId) {
 
-        // FIXME
-        Long userId = 1L;
+        Long userId = toId(getCurrentUserId());
 
         return ApiResponse.onSuccess(chatService.synchronizationChatMessages(userId, chatRoomId, lastClientMessageId));
     }
 
-    // TODO: 웹 소켓 연결이 끊어졌다가 재연결될 경우 특정 채팅방 조회
-    // TODO: 웹 소켓 연결이 끊어졌다가 재연결될 경우 모든 채팅방 조회
+    @Operation(summary = "클라이언트와 서버의 채팅방 정보 조회", description = "웹소켓 연결이 끊어지면 클라이언트와 서버 간의 채팅방 정보가 일치 하지 않을 수 있기에 이 API를 호출해서 클라이언트가 서버의 데이터를 조회하도록 시켜줍니다.")
+    @GetMapping
+    public ApiResponse<List<ChatRoomInfoResponseDto>> synchronizationChatRoomsInfo() {
+
+        Long userId = 1L; //toId(getCurrentUserId());
+
+        return ApiResponse.onSuccess(chatService.synchronizationChatRoomsInfo(userId));
+    }
+
+    // TODO: 웹 소켓 연결이 끊어졌다가 재연결될 경우 특정 채팅방 조회(필요하면)
 
     /**
      * @param chatRoomDetailRequestDto 채팅방 생성 DTO

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatController.java
@@ -126,6 +126,4 @@ public class ChatController {
         log.info("The user with senderID has left the chat room.");
         chatService.saveMessages(exitMessageDto);
     }
-
-
 }

--- a/src/main/java/com/umc/yeongkkeul/web/dto/chat/ChatRoomInfoResponseDto.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/chat/ChatRoomInfoResponseDto.java
@@ -1,0 +1,25 @@
+package com.umc.yeongkkeul.web.dto.chat;
+
+import com.umc.yeongkkeul.domain.ChatRoom;
+import lombok.Builder;
+
+@Builder
+public record ChatRoomInfoResponseDto(
+        Long chatRoomId,
+        String chatRoomTitle,
+        String chatRoomThumbnail,
+        String chatRoomRule,
+        Integer participationCount
+) {
+
+    public static ChatRoomInfoResponseDto of(ChatRoom chatRoom) {
+
+        return ChatRoomInfoResponseDto.builder()
+                .chatRoomId(chatRoom.getId())
+                .chatRoomTitle(chatRoom.getTitle())
+                .chatRoomThumbnail(chatRoom.getImageUrl())
+                .chatRoomRule(chatRoom.getDescription())
+                .participationCount(chatRoom.getParticipationCount())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/yeongkkeul/web/dto/chat/MessageDto.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/chat/MessageDto.java
@@ -15,7 +15,7 @@ public record MessageDto(
         Long senderId, // 발신인 ID
         String messageType, // 메시지 타입(텍스트, 사진, 영수증)
         String content, // 메시지 내용
-        LocalDateTime timestamp // 타임스탬프
+        String timestamp // 타임스탬프
         // TODO: Message 전송 여부, 저장 여부를 저장하는 필드가 있으면 좋을듯
 ) {
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#91 

## 📝 작업 내용
- [x] redis tsid 로직 추가 -> 이제 시간을 기준으로 unique한 ID를 가진 메시지를 저장
- [x] 웹 소켓 재연결 시 서버-클라이언트 간의 채팅 내역(메시지) 동기화
- [x] 웹 소켓 재연결 시 채팅방 정보 동기화

## 스크린샷 

## 💬 리뷰 요구사항
- 테스트 진행하고 제가 머지하겠습니다!
- 테스트 하면서 주석 추가하겠습니다.
