### PR TITLE
fix: 지출 목록 조회 시 첨부된 사진 유무 반환하도록 수정

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/converter/CategoryConverter.java
+++ b/src/main/java/com/umc/yeongkkeul/converter/CategoryConverter.java
@@ -58,12 +58,22 @@ public class CategoryConverter {
                         category.getName(),  // 카테고리 이름만 포함
                         category.getExpenseList().stream()  // Expense 리스트를 해당 유저의 지출 내역만 가져오기
                                 .filter(expense -> expense.getUser().equals(user) // 유저의 지출만!
-                                         && expense.getDay().equals(today))  // 그중에서도 today 지출만!!
+                                        && expense.getDay().equals(today))  // 그중에서도 today 지출만!!
                                 .map(expense -> new ExpenseResponseDTO.ExpenseListViewDTO(
-                                        expense.getId(), expense.getContent(), expense.getAmount()))
+                                        expense.getId(),
+                                        expense.getContent(),
+                                        expense.getAmount(),
+                                        isImageExist(expense.getImageUrl()) // expenseImg에 대한 추가적인 체크
+                                ))
                                 .collect(Collectors.toList())
                 ))
                 .collect(Collectors.toList());
+    }
+
+    // 이미지 URL이 존재하는지 체크
+    // 일단 지출 생성할 때 null로 적어서 제출했거나 빈칸으로 뒀을 때 null로 인식하고자 함
+    private static boolean isImageExist(String expenseImg) {
+        return expenseImg != null && !expenseImg.trim().isEmpty() && !expenseImg.equals("null");
     }
 
     // 지출 화면 - 일별 사용자의 카테고리별 지출 기록(목록)조회
@@ -81,7 +91,10 @@ public class CategoryConverter {
                                 .filter(expense -> expense.getUser().equals(user) // 유저의 지출만!
                                         && expense.getDay().equals(today))  // 그중에서도 today에 해당되는 지출만!!
                                 .map(expense -> new ExpenseResponseDTO.ExpenseListView2DTO(
-                                        expense.getId(), expense.getContent(), expense.getAmount()))
+                                        expense.getId(),
+                                        expense.getContent(),
+                                        expense.getAmount(),
+                                        isImageExist(expense.getImageUrl())))
                                 .collect(Collectors.toList())
                 ))
                 .collect(Collectors.toList());

--- a/src/main/java/com/umc/yeongkkeul/web/dto/ExpenseResponseDTO.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/ExpenseResponseDTO.java
@@ -19,11 +19,13 @@ public class ExpenseResponseDTO {
         private Long expenseId;
         String content;
         private Integer amount;
+        private Boolean imgExist;
 
-        public ExpenseListViewDTO(Long expenseId, String content, Integer amount) {
+        public ExpenseListViewDTO(Long expenseId, String content, Integer amount, Boolean imgExist) {
             this.expenseId = expenseId;
             this.content = content;
             this.amount = amount;
+            this.imgExist = imgExist;
         }
     }
 
@@ -34,11 +36,13 @@ public class ExpenseResponseDTO {
         private Long expenseId;
         private String expenseName;
         private Integer expenseAmount;
+        private Boolean imgExist;
 
-        public ExpenseListView2DTO(Long expenseId, String expenseName, Integer expenseAmount) {
+        public ExpenseListView2DTO(Long expenseId, String expenseName, Integer expenseAmount, Boolean imgExist) {
             this.expenseId = expenseId;
             this.expenseName = expenseName;
             this.expenseAmount = expenseAmount;
+            this.imgExist = imgExist;
         }
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#103 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 홈 화면 - 지출 목록 조회 시 첨부된 사진 유무 반환하도록 수정
- 카테고리별 지출 목록 조회 시 첨부된 사진 유무 반환하도록 수정

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
