### PR TITLE
fix: 지출 목록 조회 시 카테고리 id도 반환하도록 수정

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/converter/CategoryConverter.java
+++ b/src/main/java/com/umc/yeongkkeul/converter/CategoryConverter.java
@@ -55,6 +55,7 @@ public class CategoryConverter {
     public static List<CategoryResponseDTO.CategoryViewListWithHomeDTO> toCategoriesViewListWithHomeDTO(List<Category> categoryList, User user, LocalDate today) {
         return categoryList.stream()
                 .map(category -> new CategoryResponseDTO.CategoryViewListWithHomeDTO(
+                        category.getId(),   // 카테고리 id도 반환하도록 수정
                         category.getName(),  // 카테고리 이름만 포함
                         category.getExpenseList().stream()  // Expense 리스트를 해당 유저의 지출 내역만 가져오기
                                 .filter(expense -> expense.getUser().equals(user) // 유저의 지출만!
@@ -83,6 +84,7 @@ public class CategoryConverter {
 
         return categoryList.stream()
                 .map(category -> new CategoryResponseDTO.CategoryViewListWithExpenditureDTO(
+                        category.getId(),   // 카테고리 id도 반환하도록 수정
                         category.getName(),  // 카테고리 이름만 포함
                         category.getRed(),  // 카테고리 색상 포함
                         category.getGreen(),
@@ -126,6 +128,7 @@ public class CategoryConverter {
 
         return categoryList.stream()
                 .map(category -> new CategoryResponseDTO.CategoryViewListWithWeeklyExpenditureDTO(
+                        category.getId(),   // 카테고리 id도 반환하도록 수정
                         category.getName(),
                         category.getRed(),
                         category.getGreen(),

--- a/src/main/java/com/umc/yeongkkeul/web/dto/CategoryResponseDTO.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/CategoryResponseDTO.java
@@ -35,6 +35,7 @@ public class CategoryResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class CategoryViewListWithHomeDTO{
+        Long categoryId;
         String categoryName;
         List<ExpenseResponseDTO.ExpenseListViewDTO> expenses;
     }
@@ -44,6 +45,7 @@ public class CategoryResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class CategoryViewListWithExpenditureDTO{
+        Long categoryId;
         String categoryName;
         int red;
         int green;
@@ -56,6 +58,7 @@ public class CategoryResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class CategoryViewListWithWeeklyExpenditureDTO{
+        Long categoryId;
         String categoryName;
         int red;
         int green;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#106 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 홈 화면, 카테고리별 지출 기록 조회, 주간 통계 조회 시 카테고리 id도 반환하도록 수정

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
