### PR TITLE
fix: 컨트롤러 reqBody로 변경 및 MultipartFile 적용 확인

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/service/ChatService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ChatService.java
@@ -490,12 +490,15 @@ public class ChatService {
      * 2. 저장한 Uuid를 기반으로 S3 key 생성
      * 3. AmazonS3Manager를 통해 파일 업로드 후 S3에 저장된 URL 반환
      *
-     * @param chatRoomId 채팅방 ID (필요에 따라 추가 검증 가능)
-     * @param file 업로드할 이미지 파일
      * @return S3에 저장된 이미지 URL
      */
     @Transactional
-    public String uploadChatImage(Long chatRoomId, MultipartFile file) {
+    public String uploadChatImage(Long userId,Long chatRoomId, MultipartFile file) {
+        // chatRoomId를 통해, 유저가 해당 채팅방에 소속해있는지 점검
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        chatRoomMembershipRepository.findByUserIdAndChatroomId(userId, chatRoomId).orElseThrow(()->new ChatRoomMembershipHandler(ErrorStatus._CHATROOM_NO_PERMISSION));
+
+        // 해당 유저가 채팅방에 소속되어 권한 인증이 완료되면, 이미지를 업로드해서 url 리턴
         // 새로운 Uuid 엔티티 생성 (랜덤 UUID 문자열 생성)
         Uuid uuidEntity = Uuid.builder().uuid(UUID.randomUUID().toString()).build();
         // DB에 저장 (중복 방지)

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
@@ -177,15 +177,15 @@ public class ChatAPIController {
      * 채팅 이미지 업로드 API
      * 클라이언트는 이미지를 업로드한 후, 반환된 이미지 URL을 포함하여 채팅 메시지를 전송할 수 있습니다.
      *
-     * @param chatRoomId 채팅방 ID
-     * @param file 업로드할 이미지 파일 (Multipart 형식)
      * @return S3에 저장된 이미지 URL
      */
-    @PostMapping("/{chatRoomId}/images")
+    @PostMapping(value = "/{chatRoomId}/images", consumes = "multipart/form-data")
     @Operation(summary = "채팅 이미지 업로드", description = "채팅 이미지를 S3에 업로드하고 이미지 URL을 반환합니다.")
-    public ApiResponse<String> uploadChatImage(@PathVariable Long chatRoomId,
-                                               @RequestParam("file") MultipartFile file) {
-        String imageUrl = chatService.uploadChatImage(chatRoomId, file);
+    public ApiResponse<String> uploadChatImage(@RequestBody ImageChatRequestDTO.ImageDTO request,
+                                               @PathVariable Long chatRoomId
+                                               ) {
+        Long userId = toId(getCurrentUserId());
+        String imageUrl = chatService.uploadChatImage(userId,chatRoomId, request.getChatPicture());
         return ApiResponse.onSuccess(imageUrl);
     }
 

--- a/src/main/java/com/umc/yeongkkeul/web/dto/chat/ImageChatRequestDTO.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/chat/ImageChatRequestDTO.java
@@ -1,0 +1,13 @@
+package com.umc.yeongkkeul.web.dto.chat;
+
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+
+public class ImageChatRequestDTO {
+    @Getter
+    public static class ImageDTO{
+        MultipartFile chatPicture;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#108 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 사진 업로드 컨트롤러 api의 reqParam -> reqBody로 수정
- consumes 조건 추가

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->
![image](https://github.com/user-attachments/assets/36224182-e48d-49e7-8e01-93269605f518)

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 현재 로컬에서 잡히는 것 확인했고, 받은 이미지 url을 채팅으로 바로 쏴주도록 구현해주셔야합니다!
- 이는 업로드 로직일뿐이고, 저희 백에서 관리하는 방식이 이미지 url을 채팅 content로 넣어서 서랍기능을 구현하고 있습니다.
- 그리고 TYPE의 경우도 "IMAGE"로 넣어주셔야합니다. 

