### PR TITLE
feat: channelinterceptor를 기반한 socket의 연결 상태 추적 로직 추가

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/config/WebSocketBrokerConfig.java
+++ b/src/main/java/com/umc/yeongkkeul/config/WebSocketBrokerConfig.java
@@ -1,7 +1,10 @@
 package com.umc.yeongkkeul.config;
 
+import com.umc.yeongkkeul.socket.SocketSessionInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.messaging.simp.stomp.StompReactorNettyCodec;
 import org.springframework.messaging.tcp.reactor.ReactorNettyTcpClient;
@@ -23,6 +26,15 @@ public class WebSocketBrokerConfig implements WebSocketMessageBrokerConfigurer {
     private final String RABBITMQ_HOST;
     private final String RABBITMQ_USERNAME;
     private final String RABBITMQ_PASSWORD;
+
+    @Autowired
+    private SocketSessionInterceptor socketSessionInterceptor;
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(socketSessionInterceptor);
+    }
+
 
     public WebSocketBrokerConfig (
             @Value("${spring.rabbitmq.host}") String RABBITMQ_HOST,

--- a/src/main/java/com/umc/yeongkkeul/socket/SocketConnectionTracker.java
+++ b/src/main/java/com/umc/yeongkkeul/socket/SocketConnectionTracker.java
@@ -3,12 +3,17 @@ package com.umc.yeongkkeul.socket;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.TimeUnit;
+
 @Component
 public class SocketConnectionTracker {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private static final String ONLINE_KEY_PREFIX = "socket:online:";
-
+    // TTL 시간 - 소켓 비정상연결 종료 관리위함
+    private static final long TTL_MINUTES = 10;
+    
+    
     public SocketConnectionTracker(RedisTemplate<String, Object> redisTemplate) {
         this.redisTemplate = redisTemplate;
     }
@@ -20,7 +25,8 @@ public class SocketConnectionTracker {
      * @param userId 연결된 사용자의 고유 ID
      */
     public void setUserOnline(Long userId) {
-        redisTemplate.opsForValue().set(ONLINE_KEY_PREFIX + userId, true);
+        String key = ONLINE_KEY_PREFIX + userId;
+        redisTemplate.opsForValue().set(key, true, TTL_MINUTES, TimeUnit.MINUTES);
     }
 
     /**

--- a/src/main/java/com/umc/yeongkkeul/socket/SocketConnectionTracker.java
+++ b/src/main/java/com/umc/yeongkkeul/socket/SocketConnectionTracker.java
@@ -1,0 +1,36 @@
+package com.umc.yeongkkeul.socket;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SocketConnectionTracker {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String ONLINE_KEY_PREFIX = "socket:online:";
+
+    public SocketConnectionTracker(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /**
+     * 사용자를 온라인 상태로 표시합니다.
+     */
+    public void setUserOnline(Long userId) {
+        redisTemplate.opsForValue().set(ONLINE_KEY_PREFIX + userId, true);
+    }
+
+    /**
+     * 사용자를 오프라인 상태로 표시합니다.
+     */
+    public void setUserOffline(Long userId) {
+        redisTemplate.delete(ONLINE_KEY_PREFIX + userId);
+    }
+
+    /**
+     * 사용자의 연결 상태(온라인 여부)를 반환합니다.
+     */
+    public boolean isUserOnline(Long userId) {
+        Object status = redisTemplate.opsForValue().get(ONLINE_KEY_PREFIX + userId);
+        return status != null && (Boolean) status;
+    }
+}

--- a/src/main/java/com/umc/yeongkkeul/socket/SocketConnectionTracker.java
+++ b/src/main/java/com/umc/yeongkkeul/socket/SocketConnectionTracker.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class SocketConnectionTracker {
+
     private final RedisTemplate<String, Object> redisTemplate;
     private static final String ONLINE_KEY_PREFIX = "socket:online:";
 
@@ -13,21 +14,29 @@ public class SocketConnectionTracker {
     }
 
     /**
-     * 사용자를 온라인 상태로 표시합니다.
+     * 사용자 ID를 기반으로 온라인 상태를 Redis에 기록합니다.
+     * 필요에 따라 TTL(Time To Live)을 설정할 수도 있습니다.
+     *
+     * @param userId 연결된 사용자의 고유 ID
      */
     public void setUserOnline(Long userId) {
         redisTemplate.opsForValue().set(ONLINE_KEY_PREFIX + userId, true);
     }
 
     /**
-     * 사용자를 오프라인 상태로 표시합니다.
+     * 사용자 ID에 해당하는 온라인 상태 키를 삭제하여 오프라인 상태로 만듭니다.
+     *
+     * @param userId 연결 종료한 사용자의 고유 ID
      */
     public void setUserOffline(Long userId) {
         redisTemplate.delete(ONLINE_KEY_PREFIX + userId);
     }
 
     /**
-     * 사용자의 연결 상태(온라인 여부)를 반환합니다.
+     * 특정 사용자 ID의 온라인 여부를 반환합니다.
+     *
+     * @param userId 확인할 사용자의 고유 ID
+     * @return 온라인이면 true, 그렇지 않으면 false
      */
     public boolean isUserOnline(Long userId) {
         Object status = redisTemplate.opsForValue().get(ONLINE_KEY_PREFIX + userId);

--- a/src/main/java/com/umc/yeongkkeul/socket/SocketSessionInterceptor.java
+++ b/src/main/java/com/umc/yeongkkeul/socket/SocketSessionInterceptor.java
@@ -1,0 +1,58 @@
+package com.umc.yeongkkeul.socket;
+
+import com.umc.yeongkkeul.security.FindLoginUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SocketSessionInterceptor implements ChannelInterceptor {
+
+    private final SocketConnectionTracker tracker;
+
+    @Autowired
+    public SocketSessionInterceptor(SocketConnectionTracker tracker) {
+        this.tracker = tracker;
+    }
+
+    /**
+     * 클라이언트에서 들어오는 메시지를 가로채어 STOMP 명령어에 따라
+     * 온라인/오프라인 상태를 업데이트합니다.
+     *
+     * CONNECT: 클라이언트 연결 시, Principal을 통해 사용자 이메일을 얻고,
+     *          이를 FindLoginUser.toId()로 변환해 사용자 ID를 획득한 후 온라인 상태로 기록합니다.
+     *
+     * DISCONNECT: 클라이언트 연결 종료 시, 동일한 방식으로 사용자 ID를 획득한 후 오프라인 상태로 처리합니다.
+     */
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        // STOMP 헤더 정보를 래핑합니다.
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        if (accessor.getCommand() == null) {
+            return message;
+        }
+
+        // STOMP 명령어에 따라 처리합니다.
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            if (accessor.getUser() != null) {
+                // REST API와 동일하게 FindLoginUser를 통해 사용자 ID를 확인합니다.
+                String email = accessor.getUser().getName();
+                Long userId = FindLoginUser.toId(email);
+                tracker.setUserOnline(userId);
+                System.out.println("User " + userId + " is now ONLINE.");
+            }
+        } else if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
+            if (accessor.getUser() != null) {
+                String email = accessor.getUser().getName();
+                Long userId = FindLoginUser.toId(email);
+                tracker.setUserOffline(userId);
+                System.out.println("User " + userId + " is now OFFLINE.");
+            }
+        }
+        return message;
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#99 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- ChannelInterceptor 기반 소켓 연결 상태 추적 로직 구현
- 가입 정보와 구독 상태의 분리 관리
- 메시지 전송 로직 분기 처리

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
Redis key 네이밍이나 온라인 상태 저장 방식(TTL 적용 여부 등)에 대해 개선할 부분이 있는지 확인 부탁
채팅 전송의 서비스 로직 변환에 대해서 의견 듣고 싶습니다~