### PR TITLE
fix: 지출 월간 달력 - 하루 목표 지출액도 포함하여 반환하도록 수정

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/service/ExpenseQueryServiceImpl.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ExpenseQueryServiceImpl.java
@@ -414,6 +414,7 @@ public class ExpenseQueryServiceImpl implements ExpenseQueryService {
         int achieveDays = calculateAchieveDays(user, thisMonthExpenditureList);
 
         return ExpenseResponseDTO.MonthlyExpenditureViewDTO.builder()
+                .dayTargetExpenditure(user.getDayTargetExpenditure())
                 .totalMonthExpenditure(thisMonthExpenditure)
                 .selectedMonthExpenses(thisMonthExpenditureList)
                 .previousMonthExpenses(lastMonthExpenditureList)

--- a/src/main/java/com/umc/yeongkkeul/web/dto/ExpenseResponseDTO.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/ExpenseResponseDTO.java
@@ -117,6 +117,7 @@ public class ExpenseResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MonthlyExpenditureViewDTO {
+        Integer dayTargetExpenditure; // 하루 목표 지출액 추가
         Integer totalMonthExpenditure; // 한달 지출 누적액
         List<MonthExpenseDTO> selectedMonthExpenses; // 요청 받은 Month
         List<MonthExpenseDTO> previousMonthExpenses; // 요청 받은 Month - 1


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#124 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 지출 월간 달력 - 하루 목표 지출액도 포함하여 반환하도록 수정

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
