### PR TITLE
[FEAT] rabbitmq consumer 추가 세션 관리

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/config/RabbitMQConfig.java
+++ b/src/main/java/com/umc/yeongkkeul/config/RabbitMQConfig.java
@@ -1,13 +1,17 @@
 package com.umc.yeongkkeul.config;
 
+import com.umc.yeongkkeul.web.dto.chat.MessageDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.*;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -169,18 +173,32 @@ public class RabbitMQConfig {
     }
 
     /**
-     * RabbitMQConsumer
-     * 이 기능을 통해서 메시지를 저장, 모니터링을 비동기적으로 처리 가능
+     * @RabbitListener 애노테이션이 붙은 메소드가 메시지를 비동기적으로 처리할 수 있게 해주는 리스너 컨테이너를 설정
+     * 메시지가 큐에 도착하면, SimpleRabbitListenerContainerFactory가 자동으로 리스너 컨테이너를 관리하여 메시지를 수신하고 처리
      *
      * @param connectionFactory RabbitMQ 연결 팩토리
      * @param messageConverter Json 데이터 직렬화/역직렬화
-     *//*
+     */
     @Bean
     public SimpleRabbitListenerContainerFactory simpleRabbitListenerContainerFactory(ConnectionFactory connectionFactory, MessageConverter messageConverter) {
 
         SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
         factory.setConnectionFactory(connectionFactory);
         factory.setMessageConverter(messageConverter);
+
+        factory.setPrefetchCount(100); // 한 번에 100개만 처리 가능
+
         return factory;
-    }*/
+    }
+
+    /**
+     * 이 애노테이션은 해당 메소드가 RabbitMQ 큐로부터 메시지를 비동기적으로 수신하도록 합니다.
+     * 큐 이름을 지정하여 해당 큐로부터 전달되는 메시지를 받을 수 있습니다.
+     *
+     * @param messageDto
+     */
+    @RabbitListener(queues = "chat.queue")
+    public void receiveMessage(MessageDto messageDto) {
+        log.info("Received Message: {}", messageDto);
+    }
 }

--- a/src/main/java/com/umc/yeongkkeul/service/ChatService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ChatService.java
@@ -29,6 +29,7 @@ import com.umc.yeongkkeul.web.dto.chat.ReceiptMessageDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.ListOperations;
@@ -84,9 +85,10 @@ public class ChatService {
      */
     @Transactional
     public void sendMessage(MessageDto messageDto) {
+
         // 기존 RabbitMQ를 통한 실시간 메시지 전송 (온라인 구독자 대상) -> 온라인이면 sub 정보 남아있고, 오프라인이면 휘발돼서 상관없음
-        rabbitTemplate.convertAndSend(CHAT_EXCHANGE_NAME, ROUTING_PREFIX_KEY + messageDto.chatRoomId(), messageDto);
-        log.info("RabbitMQ를 통해 채팅방 {}에 메시지 전송: {}", messageDto.chatRoomId(), messageDto);
+        rabbitTemplate.convertAndSend(CHAT_EXCHANGE_NAME, ROUTING_PREFIX_KEY + messageDto.chatRoomId(), messageDto, new CorrelationData(UUID.randomUUID().toString()));
+        // log.info("RabbitMQ를 통해 채팅방 {}에 메시지 전송: {}", messageDto.chatRoomId(), messageDto);
 
         // 해당 채팅방의 모든 멤버 조회 (MySQL의 membership 테이블)
         List<ChatRoomMembership> memberships = chatRoomMembershipRepository.findByChatroomIdOrderByUserScoreDesc(messageDto.chatRoomId());
@@ -114,7 +116,7 @@ public class ChatService {
      */
     private void enterMessage(MessageDto messageDto) {
 
-        rabbitTemplate.convertAndSend(CHAT_EXCHANGE_NAME, ROUTING_PREFIX_KEY + messageDto.chatRoomId(), messageDto);
+        rabbitTemplate.convertAndSend(CHAT_EXCHANGE_NAME, ROUTING_PREFIX_KEY + messageDto.chatRoomId(), messageDto, new CorrelationData(UUID.randomUUID().toString()));
     }
 
     /**
@@ -125,7 +127,7 @@ public class ChatService {
      */
     public void exitMessage(MessageDto messageDto) {
 
-        rabbitTemplate.convertAndSend(CHAT_EXCHANGE_NAME, ROUTING_PREFIX_KEY + messageDto.chatRoomId(), messageDto);
+        rabbitTemplate.convertAndSend(CHAT_EXCHANGE_NAME, ROUTING_PREFIX_KEY + messageDto.chatRoomId(), messageDto, new CorrelationData(UUID.randomUUID().toString()));
     }
 
     /**
@@ -613,7 +615,7 @@ public class ChatService {
      */
     public void expelMessage(MessageDto messageDto) {
 
-        rabbitTemplate.convertAndSend(CHAT_EXCHANGE_NAME, ROUTING_PREFIX_KEY + messageDto.chatRoomId(), messageDto);
+        rabbitTemplate.convertAndSend(CHAT_EXCHANGE_NAME, ROUTING_PREFIX_KEY + messageDto.chatRoomId(), messageDto, new CorrelationData(UUID.randomUUID().toString()));
     }
 
     @Transactional

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatController.java
@@ -49,7 +49,7 @@ public class ChatController {
 
         chatService.sendMessage(message); // 메시지 전송
 
-        log.info("Send a message to the group chat room with roomID");
+        log.info("Send a message to the group chat room with roomID {}", roomId);
         chatService.saveMessages(message); // 메시지 저장 TODO: 나중에 Consumer를 통해서 저장하자
     }
 
@@ -91,7 +91,7 @@ public class ChatController {
             log.error("error {}.", e); return;
         }
 
-        log.info("The user with senderID has entered the chat room."); // JPA 저장과 메시지 전송이 성공함.
+        log.info("The user with senderID {} has entered the chat room {}.", enterMessageDto.senderId(), roomId); // JPA 저장과 메시지 전송이 성공함.
         chatService.saveMessages(messageDto); // Redis에 가입 메시지 저장
     }
 
@@ -123,7 +123,7 @@ public class ChatController {
             log.error("error {}.", e); return;
         }
 
-        log.info("The user with senderID has left the chat room.");
+        log.info("The user with senderID {} has left the chat room {}.", exitMessageDto.senderId(), roomId);
         chatService.saveMessages(exitMessageDto);
     }
     // 유저가 특정 채팅방의 방장일 때, 특정 사용자를 퇴출시키는 경우

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatController.java
@@ -9,9 +9,13 @@ import com.umc.yeongkkeul.web.dto.chat.MessageDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.AmqpException;
+import org.springframework.context.event.EventListener;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -126,6 +130,7 @@ public class ChatController {
         log.info("The user with senderID {} has left the chat room {}.", exitMessageDto.senderId(), roomId);
         chatService.saveMessages(exitMessageDto);
     }
+
     // 유저가 특정 채팅방의 방장일 때, 특정 사용자를 퇴출시키는 경우
     @MessageMapping("chat.expel.{roomId}.{targetUserId}")
     public void expelUser(
@@ -152,4 +157,27 @@ public class ChatController {
         chatService.saveMessages(expelMessageDto);
     }
 
+    // 새로운 사용자가 웹 소켓을 연결할 때 실행됨
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectEvent event) {
+
+        StompHeaderAccessor headerAccesor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headerAccesor.getSessionId();
+
+        // TODO: 로그인 정보 포함
+
+        log.info("Received a new web socket connection : {}", sessionId);
+    }
+
+    // 사용자가 웹 소켓 연결을 끊으면 실행됨
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+
+        StompHeaderAccessor headerAccesor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = headerAccesor.getSessionId();
+
+        // TODO: 로그인 정보 포함
+
+        log.info("sessionId Disconnected : " + sessionId);
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#118 

## 📝 작업 내용
- [x] RabbitMQ Consumer 구현
- [x] RabbitMQ 예외 처리
- [x] WebSocket 세션 모니터링

## 기능 설명
- RabbitMQ의 메시지를 소비하지 않으면 큐에 메시지가 쌓여 RabbitMQ의 메모리에 부담이 됩니다.
- 그렇기에 consumer를 추가하여 메시지를 비우고 비동기적으로 redis에 메시지를 저장하는 로직을 구현합니다.
- **현재 단계에서는 비동기적으로 저장하는 로직을 구현하지 않고 클라이언트와 연동한 다음에 구현하겠습니다.** 


- 메시지가 정상적으로 RabbitMQ에 전송되었는지, 정상적으로 해당 큐로 전송이 되었는지 확인하는 코드를 작성했습니다.
- 그리고 추후에 재전송 로직을 추가할 예정입니다.


- WebSocket을 통해 접속한 사용자의 세션 ID를 로그에 기록합니다.
