### PR TITLE
feat: 채팅방 정보 조회 시 필요 데이터 갱신 #120

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/batch/BatchScheduler.java
+++ b/src/main/java/com/umc/yeongkkeul/batch/BatchScheduler.java
@@ -1,30 +1,30 @@
-//package com.umc.yeongkkeul.batch;
-//
-//import lombok.AllArgsConstructor;
-//import org.springframework.batch.core.Job;
-//import org.springframework.batch.core.JobParameters;
-//import org.springframework.batch.core.JobParametersBuilder;
-//import org.springframework.batch.core.launch.JobLauncher;
-//import org.springframework.scheduling.annotation.Scheduled;
-//import org.springframework.stereotype.Component;
-//
-//@Component
-//@AllArgsConstructor
-//public class BatchScheduler {
-//
-//    private final JobLauncher jobLauncher;
-//    private final Job updateUserScoreJob;
-//    private final Job updateChatRoomScoreJob;
-//    private final Job updateChatRoomJob;
-//
-//    @Scheduled(cron = "0 0 0 * * ?")
-//    public void runBatchJobs() throws Exception{
-//        JobParameters jobParameters = new JobParametersBuilder()
-//                .addLong("timestamp",System.currentTimeMillis())
-//                .toJobParameters();
-//
-//        jobLauncher.run(updateUserScoreJob,jobParameters);
-//        jobLauncher.run(updateChatRoomScoreJob,jobParameters);
-//        jobLauncher.run(updateChatRoomJob,jobParameters);
-//    }
-//}
+package com.umc.yeongkkeul.batch;
+
+import lombok.AllArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class BatchScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job updateUserScoreJob;
+    private final Job updateChatRoomScoreJob;
+    private final Job updateChatRoomJob;
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void runBatchJobs() throws Exception{
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLong("timestamp",System.currentTimeMillis())
+                .toJobParameters();
+
+        jobLauncher.run(updateUserScoreJob,jobParameters);
+        jobLauncher.run(updateChatRoomScoreJob,jobParameters);
+        jobLauncher.run(updateChatRoomJob,jobParameters);
+    }
+}

--- a/src/main/java/com/umc/yeongkkeul/batch/BatchScheduler.java
+++ b/src/main/java/com/umc/yeongkkeul/batch/BatchScheduler.java
@@ -1,28 +1,30 @@
-package com.umc.yeongkkeul.batch;
-
-import lombok.AllArgsConstructor;
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.JobParametersBuilder;
-import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
-
-@Component
-@AllArgsConstructor
-public class BatchScheduler {
-
-    private final JobLauncher jobLauncher;
-    private final Job updateUserScoreJob;
-    private final Job updateChatRoomScoreJob;
-
-    @Scheduled(cron = "0 0 0 * * ?")
-    public void runBatchJobs() throws Exception{
-        JobParameters jobParameters = new JobParametersBuilder()
-                .addLong("timestamp",System.currentTimeMillis())
-                .toJobParameters();
-
-        jobLauncher.run(updateUserScoreJob,jobParameters);
-        jobLauncher.run(updateChatRoomScoreJob,jobParameters);
-    }
-}
+//package com.umc.yeongkkeul.batch;
+//
+//import lombok.AllArgsConstructor;
+//import org.springframework.batch.core.Job;
+//import org.springframework.batch.core.JobParameters;
+//import org.springframework.batch.core.JobParametersBuilder;
+//import org.springframework.batch.core.launch.JobLauncher;
+//import org.springframework.scheduling.annotation.Scheduled;
+//import org.springframework.stereotype.Component;
+//
+//@Component
+//@AllArgsConstructor
+//public class BatchScheduler {
+//
+//    private final JobLauncher jobLauncher;
+//    private final Job updateUserScoreJob;
+//    private final Job updateChatRoomScoreJob;
+//    private final Job updateChatRoomJob;
+//
+//    @Scheduled(cron = "0 0 0 * * ?")
+//    public void runBatchJobs() throws Exception{
+//        JobParameters jobParameters = new JobParametersBuilder()
+//                .addLong("timestamp",System.currentTimeMillis())
+//                .toJobParameters();
+//
+//        jobLauncher.run(updateUserScoreJob,jobParameters);
+//        jobLauncher.run(updateChatRoomScoreJob,jobParameters);
+//        jobLauncher.run(updateChatRoomJob,jobParameters);
+//    }
+//}

--- a/src/main/java/com/umc/yeongkkeul/batch/ChatRoomBatchConfig.java
+++ b/src/main/java/com/umc/yeongkkeul/batch/ChatRoomBatchConfig.java
@@ -18,11 +18,13 @@ import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.batch.item.database.builder.JpaItemWriterBuilder;
 import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.batch.item.support.CompositeItemProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Configuration
@@ -50,7 +52,7 @@ public class ChatRoomBatchConfig {
         return new StepBuilder("updateChatRoomStep", jobRepository)
                 .<ChatRoom, ChatRoom>chunk(10, transactionManager)
                 .reader(chatRoomItemReader())
-                .processor(chatRoomItemProcessor())
+                .processor(chatRoomCompositeProcessor())
                 .writer(chatRoomItemWriter())
                 .build();
     }
@@ -66,14 +68,8 @@ public class ChatRoomBatchConfig {
     }
 
     @Bean
-    public ItemProcessor<ChatRoom, ChatRoom> chatRoomItemProcessor() {
+    public ItemProcessor<ChatRoom, ChatRoom> expenseProcessor() { // 목표 달성 인원, 지출 평균 계산
         return chatRoom -> {
-
-            // ------------------------------
-            // 채팅방 내 목표 달성 인원, 지출 평균 계산
-            // ------------------------------
-
-            // 특정 채팅방의 유저 리스트
             List<Long> userIdList = chatRoomMembershipRepository.findUserIdByChatroomId(chatRoom.getId());
 
             int achievedCount = 0; // 하루 목표 달성한 유저 수
@@ -89,7 +85,6 @@ public class ChatRoomBatchConfig {
 
                 int totalExpenditure = totalExpenditureLong.intValue();
 
-                // 하루 목표 달성한 유저 수 count (유저의 하루 지출 총액 <= 채팅방의 하루 목표 지출 금액)
                 if (totalExpenditure <= chatRoom.getDailySpendingGoalFilter()) {
                     achievedCount++;
                 }
@@ -106,9 +101,16 @@ public class ChatRoomBatchConfig {
             chatRoom.setAchievedCount(achievedCount); // 목표 달성 인원 설정
             chatRoom.setAverageExpense(averageExpense); // 지출 평균 설정
 
-            // ------------------------------
-            // 채팅방 랭킹 (백분위) 계산
-            // ------------------------------
+            return chatRoom;
+        };
+    }
+
+    @Bean
+    public ItemProcessor<ChatRoom, ChatRoom> rankingProcessor() { // 백분위 계산 로직
+        return chatRoom -> {
+            if (chatRoom.getTotalScore() == null) { // totalScore가 null인 경우(5명 이하인 채팅방은 null)
+                return null;
+            }
 
             AgeGroup ageFilter = chatRoom.getAgeGroupFilter(); // age 필터
             com.umc.yeongkkeul.domain.enums.Job jobFilter = chatRoom.getJobFilter(); // job 필터
@@ -127,20 +129,31 @@ public class ChatRoomBatchConfig {
                 chatRoomList = chatRoomRepository.findAllByOrderByTotalScoreDesc();
             }
 
-            // 채팅방 백분위 계산
-            int ranking = chatRoomList.stream()
-                    .filter(c -> c.getId().equals(chatRoom.getId()))
-                    .map(chatRoomList::indexOf)
-                    .findFirst()
-                    .map(i -> i + 1) // 인덱스 1부터 시작
-                    .orElse(0);
+            int rank = 1;
+            for (int i = 0; i < chatRoomList.size(); i++) {
+                if (chatRoomList.get(i).getId().equals(chatRoom.getId())) {
+                    rank = i + 1;
+                    break;
+                }
+            }
 
-            int topRate = (int) Math.round(((double) ranking / chatRoomList.size()) * 100); // 소수점 반올림
-
+            int topRate = (int) Math.round(((double) rank / chatRoomList.size()) * 100);
             chatRoom.setRanking(topRate);
 
             return chatRoom;
         };
+    }
+
+    @Bean
+    public CompositeItemProcessor<ChatRoom, ChatRoom> chatRoomCompositeProcessor() {
+        List<ItemProcessor<ChatRoom, ChatRoom>> processors = new ArrayList<>();
+        processors.add(expenseProcessor());  // 목표 달성 인원 및 지출 평균 계산
+        processors.add(rankingProcessor());  // 백분위 계산
+
+        CompositeItemProcessor<ChatRoom, ChatRoom> processor = new CompositeItemProcessor<>();
+        processor.setDelegates(processors);
+
+        return processor;
     }
 
     @Bean

--- a/src/main/java/com/umc/yeongkkeul/batch/ChatRoomBatchConfig.java
+++ b/src/main/java/com/umc/yeongkkeul/batch/ChatRoomBatchConfig.java
@@ -1,0 +1,152 @@
+package com.umc.yeongkkeul.batch;
+
+import com.umc.yeongkkeul.domain.ChatRoom;
+import com.umc.yeongkkeul.domain.enums.AgeGroup;
+import com.umc.yeongkkeul.repository.ChatRoomMembershipRepository;
+import com.umc.yeongkkeul.repository.ChatRoomRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.builder.JpaItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableBatchProcessing
+public class ChatRoomBatchConfig {
+
+    private final JobRepository jobRepository;
+    private final ChatRoomMembershipRepository chatRoomMembershipRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final EntityManagerFactory entityManagerFactory;
+    private final EntityManager entityManager;
+    private final PlatformTransactionManager transactionManager;
+
+    // ChatRoom의 목표 달성 챌린저 인원, 지출 평균, 랭킹 갱신
+    @Bean
+    public Job updateChatRoomJob() {
+        return new JobBuilder("updateChatRoomJob", jobRepository)
+                .start(updateChatRoomStep())
+                .build();
+    }
+
+    @Bean
+    public Step updateChatRoomStep() {
+        return new StepBuilder("updateChatRoomStep", jobRepository)
+                .<ChatRoom, ChatRoom>chunk(10, transactionManager)
+                .reader(chatRoomItemReader())
+                .processor(chatRoomItemProcessor())
+                .writer(chatRoomItemWriter())
+                .build();
+    }
+
+    @Bean
+    public ItemReader<ChatRoom> chatRoomItemReader() {
+        return new JpaPagingItemReaderBuilder<ChatRoom>()
+                .name("chatRoomItemReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("SELECT c FROM ChatRoom c ORDER BY c.id ASC")
+                .pageSize(10)
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<ChatRoom, ChatRoom> chatRoomItemProcessor() {
+        return chatRoom -> {
+
+            // ------------------------------
+            // 채팅방 내 목표 달성 인원, 지출 평균 계산
+            // ------------------------------
+
+            // 특정 채팅방의 유저 리스트
+            List<Long> userIdList = chatRoomMembershipRepository.findUserIdByChatroomId(chatRoom.getId());
+
+            int achievedCount = 0; // 하루 목표 달성한 유저 수
+            int sumAmount = 0; // 지출 통계를 위한 합계
+            LocalDate yesterday = LocalDate.now().minusDays(1);
+            for (Long userId : userIdList) {
+                // 어제 지출 총합 계산
+                Long totalExpenditureLong = (Long) entityManager.createQuery(
+                                "SELECT COALESCE(SUM(e.amount), 0) FROM Expense e WHERE e.user.id = :userId AND e.day = :yesterday")
+                        .setParameter("userId", userId)
+                        .setParameter("yesterday", yesterday)
+                        .getSingleResult();
+
+                int totalExpenditure = totalExpenditureLong.intValue();
+
+                // 하루 목표 달성한 유저 수 count (유저의 하루 지출 총액 <= 채팅방의 하루 목표 지출 금액)
+                if (totalExpenditure <= chatRoom.getDailySpendingGoalFilter()) {
+                    achievedCount++;
+                }
+                sumAmount += totalExpenditure; // 유저들의 하루 지출
+            }
+
+            // 채팅방 총 참여자 수 TODO: 테스트 후 데이터 정리하고 아래 코드로 변경
+            int chatRoomUserCount = chatRoomMembershipRepository.countByChatroomId(chatRoom.getId());
+//            int chatRoomUserCount = chatRoom.getParticipationCount();
+
+            // 지출 평균 계산
+            int averageExpense = sumAmount / chatRoomUserCount;
+
+            chatRoom.setAchievedCount(achievedCount); // 목표 달성 인원 설정
+            chatRoom.setAverageExpense(averageExpense); // 지출 평균 설정
+
+            // ------------------------------
+            // 채팅방 랭킹 (백분위) 계산
+            // ------------------------------
+
+            AgeGroup ageFilter = chatRoom.getAgeGroupFilter(); // age 필터
+            com.umc.yeongkkeul.domain.enums.Job jobFilter = chatRoom.getJobFilter(); // job 필터
+
+            // job, age 기준으로 필터링 (totalScore null 아닌 방만 랭킹 집계)
+            List<ChatRoom> chatRoomList = new ArrayList<>();
+            if (ageFilter != null && !"UNDECIDED".equals(ageFilter) && jobFilter != null && !"UNDECIDED".equals(jobFilter)) { // age, job 대상
+                chatRoomList = chatRoomRepository.findAllByAgeGroupFilterAndJobFilterOrderByTotalScoreDesc(ageFilter, jobFilter);
+            } else if (ageFilter != null && !"UNDECIDED".equals(ageFilter) && (jobFilter == null || "UNDECIDED".equals(jobFilter))) { // age 대상
+                chatRoomList = chatRoomRepository.findAllByAgeGroupFilterOrderByTotalScoreDesc(ageFilter);
+            } else if (jobFilter != null && !"UNDECIDED".equals(jobFilter) && (ageFilter == null || "UNDECIDED".equals(ageFilter))) { // job 대상
+                chatRoomList = chatRoomRepository.findAllByJobFilterOrderByTotalScoreDesc(jobFilter);
+            } else { // 필터 없을 때는 전체 대상
+                chatRoomList = chatRoomRepository.findAllByOrderByTotalScoreDesc();
+            }
+
+            // 채팅방 백분위 계산
+            Double topRate = null; // 5명 이하일 때 null 반환 위해 null 초기화
+            int ranking = 1;
+            for (int i = 0; i < chatRoomList.size(); i++) {
+                if (chatRoomList.get(i).getId().equals(chatRoom.getId())) {
+                    ranking = i + 1;
+                    break;
+                }
+            }
+            topRate = ((double) ranking / chatRoomList.size()) * 100.0;
+
+            chatRoom.setRanking(topRate);
+
+            return chatRoom;
+        };
+    }
+
+    @Bean
+    public ItemWriter<ChatRoom> chatRoomItemWriter() {
+        return new JpaItemWriterBuilder<ChatRoom>()
+                .entityManagerFactory(entityManagerFactory)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/yeongkkeul/batch/ChatRoomBatchConfig.java
+++ b/src/main/java/com/umc/yeongkkeul/batch/ChatRoomBatchConfig.java
@@ -97,9 +97,9 @@ public class ChatRoomBatchConfig {
                 sumAmount += totalExpenditure; // 유저들의 하루 지출
             }
 
-            // 채팅방 총 참여자 수 TODO: 테스트 후 데이터 정리하고 아래 코드로 변경
-            int chatRoomUserCount = chatRoomMembershipRepository.countByChatroomId(chatRoom.getId());
-//            int chatRoomUserCount = chatRoom.getParticipationCount();
+            // 채팅방 총 참여자 수
+//            int chatRoomUserCount = chatRoomMembershipRepository.countByChatroomId(chatRoom.getId());
+            int chatRoomUserCount = chatRoom.getParticipationCount();
 
             // 지출 평균 계산
             int averageExpense = sumAmount / chatRoomUserCount;

--- a/src/main/java/com/umc/yeongkkeul/batch/ChatRoomScoreBatchConfig.java
+++ b/src/main/java/com/umc/yeongkkeul/batch/ChatRoomScoreBatchConfig.java
@@ -66,6 +66,12 @@ public class ChatRoomScoreBatchConfig {
             List<ChatRoomMembership> chatRoomMembershipList = chatRoomMembershipRepository.findByChatroomIdOrderByUserScoreDesc(chatRoom.getId());
 
             if (chatRoomMembershipList.size() >= 5) { // 5명 이상인 방만 점수 계산
+
+                // userScore가 null 아닌 유저만 남기기
+                chatRoomMembershipList = chatRoomMembershipList.stream()
+                        .filter(membership -> membership.getUserScore() != null)
+                        .toList();
+
                 // totalScore = 참여자들의 score 합
                 double totalScore = chatRoomMembershipList.stream()
                         .mapToDouble(ChatRoomMembership::getUserScore)

--- a/src/main/java/com/umc/yeongkkeul/batch/ChatRoomScoreBatchConfig.java
+++ b/src/main/java/com/umc/yeongkkeul/batch/ChatRoomScoreBatchConfig.java
@@ -44,16 +44,16 @@ public class ChatRoomScoreBatchConfig {
     public Step updateChatRoomScoreStep() {
         return new StepBuilder("updateChatRoomScoreStep", jobRepository)
                 .<ChatRoom, ChatRoom>chunk(10, transactionManager)
-                .reader(chatRoomItemReader())
-                .processor(chatRoomItemProcessor())
-                .writer(chatRoomItemWriter())
+                .reader(chatRoomScoreItemReader())
+                .processor(chatRoomScoreItemProcessor())
+                .writer(chatRoomScoreItemWriter())
                 .build();
     }
 
     @Bean
-    public ItemReader<ChatRoom> chatRoomItemReader() {
+    public ItemReader<ChatRoom> chatRoomScoreItemReader() {
         return new JpaPagingItemReaderBuilder<ChatRoom>()
-                .name("chatRoomItemReader")
+                .name("chatRoomScoreItemReader")
                 .entityManagerFactory(entityManagerFactory)
                 .queryString("SELECT c FROM ChatRoom c ORDER BY c.id ASC")
                 .pageSize(10)
@@ -61,7 +61,7 @@ public class ChatRoomScoreBatchConfig {
     }
 
     @Bean
-    public ItemProcessor<ChatRoom, ChatRoom> chatRoomItemProcessor() {
+    public ItemProcessor<ChatRoom, ChatRoom> chatRoomScoreItemProcessor() {
         return chatRoom -> {
             List<ChatRoomMembership> chatRoomMembershipList = chatRoomMembershipRepository.findByChatroomIdOrderByUserScoreDesc(chatRoom.getId());
 
@@ -99,7 +99,7 @@ public class ChatRoomScoreBatchConfig {
     }
 
     @Bean
-    public ItemWriter<ChatRoom> chatRoomItemWriter() { // 최종 점수 저장
+    public ItemWriter<ChatRoom> chatRoomScoreItemWriter() { // 최종 점수 저장
         return new JpaItemWriterBuilder<ChatRoom>()
                 .entityManagerFactory(entityManagerFactory)
                 .build();

--- a/src/main/java/com/umc/yeongkkeul/domain/ChatRoom.java
+++ b/src/main/java/com/umc/yeongkkeul/domain/ChatRoom.java
@@ -77,9 +77,9 @@ public class ChatRoom extends BaseEntity {
     @Column(name = "average_expense")
     private Integer averageExpense;
 
-    // 채팅방 순위
-    @Column(name = "Ranking")
-    private Double ranking;
+    // 채팅방 순위(필터링 백분위)
+    @Column(name = "ranking")
+    private Integer ranking;
 
     @OneToMany(mappedBy = "chatroom", cascade = CascadeType.ALL)
     private List<ChatRoomMembership> chatRoomMembershipList = new ArrayList<>();

--- a/src/main/java/com/umc/yeongkkeul/domain/ChatRoom.java
+++ b/src/main/java/com/umc/yeongkkeul/domain/ChatRoom.java
@@ -69,6 +69,18 @@ public class ChatRoom extends BaseEntity {
     @Column(name = "total_score")
     private Double totalScore;
 
+    // 목표 달성 인원
+    @Column(name = "achieved_count")
+    private Integer achievedCount;
+
+    // 챌린저 지출 평균
+    @Column(name = "average_expense")
+    private Integer averageExpense;
+
+    // 채팅방 순위
+    @Column(name = "Ranking")
+    private Double ranking;
+
     @OneToMany(mappedBy = "chatroom", cascade = CascadeType.ALL)
     private List<ChatRoomMembership> chatRoomMembershipList = new ArrayList<>();
 

--- a/src/main/java/com/umc/yeongkkeul/repository/ChatRoomRepository.java
+++ b/src/main/java/com/umc/yeongkkeul/repository/ChatRoomRepository.java
@@ -33,9 +33,27 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     @Query("SELECT c FROM ChatRoom c WHERE c.id IN :chatRoomIds")
     List<ChatRoom> findAllByIdIn(@Param("chatRoomIds") List<Long> chatRoomIds);
 
-    List<ChatRoom> findAllByAgeGroupFilterAndJobFilterOrderByTotalScoreDesc(AgeGroup ageGroupFilter, Job jobFilter);
+    @Query("SELECT c FROM ChatRoom c JOIN c.chatRoomMembershipList m " +
+            "WHERE c.ageGroupFilter = :ageGroupFilter AND c.jobFilter = :jobFilter " +
+            "AND c.totalScore IS NOT NULL " +
+            "ORDER BY c.totalScore DESC")
+    List<ChatRoom> findAllByAgeGroupFilterAndJobFilterOrderByTotalScoreDesc(@Param("ageGroupFilter") AgeGroup ageGroupFilter,
+                                                                            @Param("jobFilter") Job jobFilter);
 
-    List<ChatRoom> findAllByAgeGroupFilterOrderByTotalScoreDesc(AgeGroup ageGroupFilter);
+    @Query("SELECT c FROM ChatRoom c JOIN c.chatRoomMembershipList m " +
+            "WHERE c.ageGroupFilter = :ageGroupFilter " +
+            "AND c.totalScore IS NOT NULL " +
+            "ORDER BY c.totalScore DESC")
+    List<ChatRoom> findAllByAgeGroupFilterOrderByTotalScoreDesc(@Param("ageGroupFilter") AgeGroup ageGroupFilter);
 
-    List<ChatRoom> findAllByJobFilterOrderByTotalScoreDesc(Job jobFilter);
+    @Query("SELECT c FROM ChatRoom c JOIN c.chatRoomMembershipList m " +
+            "WHERE c.jobFilter = :jobFilter " +
+            "AND c.totalScore IS NOT NULL " +
+            "ORDER BY c.totalScore DESC")
+    List<ChatRoom> findAllByJobFilterOrderByTotalScoreDesc(@Param("jobFilter") Job jobFilter);
+
+    @Query("SELECT c FROM ChatRoom c JOIN c.chatRoomMembershipList m " +
+            "WHERE c.totalScore IS NOT NULL " +
+            "ORDER BY c.totalScore DESC")
+    List<ChatRoom> findAllByOrderByTotalScoreDesc();
 }

--- a/src/main/java/com/umc/yeongkkeul/service/ChatRoomQueryService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ChatRoomQueryService.java
@@ -1,7 +1,6 @@
 package com.umc.yeongkkeul.service;
 
 import com.umc.yeongkkeul.apiPayload.code.status.ErrorStatus;
-import com.umc.yeongkkeul.apiPayload.exception.GeneralException;
 import com.umc.yeongkkeul.apiPayload.exception.handler.ChatRoomHandler;
 import com.umc.yeongkkeul.domain.ChatRoom;
 import com.umc.yeongkkeul.repository.ChatRoomRepository;

--- a/src/main/java/com/umc/yeongkkeul/service/ChatRoomQueryService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ChatRoomQueryService.java
@@ -1,111 +1,30 @@
 package com.umc.yeongkkeul.service;
 
 import com.umc.yeongkkeul.apiPayload.code.status.ErrorStatus;
-import com.umc.yeongkkeul.apiPayload.exception.handler.ChatRoomHandler;
+import com.umc.yeongkkeul.apiPayload.exception.GeneralException;
 import com.umc.yeongkkeul.domain.ChatRoom;
-import com.umc.yeongkkeul.domain.Expense;
-import com.umc.yeongkkeul.domain.enums.AgeGroup;
-import com.umc.yeongkkeul.domain.enums.Job;
-import com.umc.yeongkkeul.repository.ChatRoomMembershipRepository;
 import com.umc.yeongkkeul.repository.ChatRoomRepository;
-import com.umc.yeongkkeul.repository.ExpenseRepository;
 import com.umc.yeongkkeul.web.dto.BannerResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ChatRoomQueryService {
 
     private final ChatRoomRepository chatRoomRepository;
-    private final ChatRoomMembershipRepository chatRoomMembershipRepository;
-    private final ExpenseRepository expenseRepository;
 
-    // TODO : 배너 api 배치를 통해 저장된 값 보여주도록 수 (배너에서는 필터 없으면 null로 / 채팅방 조회에서는 필터 없으면 전체 백분위로)
     public BannerResponseDto getChatRoomBanner(Long chatRoomId) {
 
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-                .orElseThrow(() -> new ChatRoomHandler(ErrorStatus._CHATROOM_NOT_FOUND));
+            .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
 
-        // 해당 채팅방의 유저 리스트
-        List<Long> userIdList = chatRoomMembershipRepository.findUserIdByChatroomId(chatRoomId);
-
-        int achievingCount = 0; // 하루 목표 달성한 유저 수
-        int sumAmount = 0; // 지출 통계를 위한 합계
-        for (Long userId : userIdList) {
-            LocalDate yesterday = LocalDate.now().minusDays(1);
-            List<Expense> expenseList = expenseRepository.findYesterdayExpenseByUserId(userId, yesterday);
-
-            int userAmount = 0; // 유저의 하루 지출 총액
-            for (Expense expense : expenseList) {
-                userAmount += expense.getAmount();
-            }
-
-            // 하루 목표 달성한 유저 수 count (유저의 하루 지출 총액 <= 채팅방의 하루 목표 지출 금액)
-            if (userAmount <= chatRoom.getDailySpendingGoalFilter()) {
-                achievingCount++;
-            }
-            sumAmount += userAmount;
-        }
-
-        // 채팅방 총 참여자 수
-        int chatRoomUserCount = chatRoomMembershipRepository.countByChatroomId(chatRoomId);
-
-        // 지출 평균
-        int avgAmount = sumAmount / chatRoomUserCount;
-
-        // age 필터
-        AgeGroup ageFilter = chatRoom.getAgeGroupFilter();
-        String age = (ageFilter != null) ? ageFilter.getAgeGroup() : null;
-
-        // job 필터
-        Job jobFilter = chatRoom.getJobFilter();
-        String job = (jobFilter != null) ? jobFilter.getJob() : null;
-
-        // job, age 기준으로 필터링
-        List<ChatRoom> chatRoomList = Collections.emptyList();;
-        if (ageFilter != null && !"UNDECIDED".equals(ageFilter) && jobFilter != null && !"UNDECIDED".equals(jobFilter)) { // age, job
-            chatRoomList = chatRoomRepository.findAllByAgeGroupFilterAndJobFilterOrderByTotalScoreDesc(ageFilter, jobFilter);
-        } else if (ageFilter != null && !"UNDECIDED".equals(ageFilter) && (jobFilter == null || "UNDECIDED".equals(jobFilter))) { // age
-            chatRoomList = chatRoomRepository.findAllByAgeGroupFilterOrderByTotalScoreDesc(ageFilter);
-        } else if (jobFilter != null && !"UNDECIDED".equals(jobFilter) && (ageFilter == null || "UNDECIDED".equals(ageFilter))) { // job
-            chatRoomList = chatRoomRepository.findAllByJobFilterOrderByTotalScoreDesc(jobFilter);
-        }
-
-        // null 아닌 방만 남기기
-        List<ChatRoom> chatRooms = chatRoomList.stream()
-                .filter(room -> room.getTotalScore() != null)
-                .toList();
-
-        // 채팅방 백분위 계산 (chatRoom totalScore Batch 돌린 값)
-        Double topRate = null; // age, job 없을 때, 5명 이하일 때 null 반환 위함
-        if (chatRooms.size() >= 5) { // 5명 이상인 방만 계산
-            int ranking = 1;
-            for (int i = 0; i < chatRooms.size(); i++) {
-                if (chatRooms.get(i).getId().equals(chatRoom.getId())) {
-                    ranking = i + 1;
-                    break;
-                }
-            }
-            topRate = ((double) ranking / chatRooms.size()) * 100.0;
-        }
-
-        // 배너 기준 날짜 (공지하는 날짜 - 오늘)
+        // 배너 기준 날짜 (공지하는 날짜 = 오늘)
         String createdAt = LocalDate.now().format(DateTimeFormatter.ofPattern("MM.dd"));
 
-        return BannerResponseDto.builder()
-                .achievingCount(achievingCount)
-                .chatRoomUserCount(chatRoomUserCount)
-                .avgAmount(avgAmount)
-                .age(age)
-                .job(job)
-                .topRate(topRate)
-                .createdAt(createdAt)
-                .build();
+        return BannerResponseDto.from(chatRoom, createdAt);
     }
 }

--- a/src/main/java/com/umc/yeongkkeul/service/ChatRoomQueryService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ChatRoomQueryService.java
@@ -2,6 +2,7 @@ package com.umc.yeongkkeul.service;
 
 import com.umc.yeongkkeul.apiPayload.code.status.ErrorStatus;
 import com.umc.yeongkkeul.apiPayload.exception.GeneralException;
+import com.umc.yeongkkeul.apiPayload.exception.handler.ChatRoomHandler;
 import com.umc.yeongkkeul.domain.ChatRoom;
 import com.umc.yeongkkeul.repository.ChatRoomRepository;
 import com.umc.yeongkkeul.web.dto.BannerResponseDto;
@@ -20,7 +21,7 @@ public class ChatRoomQueryService {
     public BannerResponseDto getChatRoomBanner(Long chatRoomId) {
 
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus._CHATROOM_NOT_FOUND));
+            .orElseThrow(() -> new ChatRoomHandler(ErrorStatus._CHATROOM_NOT_FOUND));
 
         // 배너 기준 날짜 (공지하는 날짜 = 오늘)
         String createdAt = LocalDate.now().format(DateTimeFormatter.ofPattern("MM.dd"));

--- a/src/main/java/com/umc/yeongkkeul/service/ChatRoomQueryService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ChatRoomQueryService.java
@@ -26,6 +26,7 @@ public class ChatRoomQueryService {
     private final ChatRoomMembershipRepository chatRoomMembershipRepository;
     private final ExpenseRepository expenseRepository;
 
+    // TODO : 배너 api 배치를 통해 저장된 값 보여주도록 수 (배너에서는 필터 없으면 null로 / 채팅방 조회에서는 필터 없으면 전체 백분위로)
     public BannerResponseDto getChatRoomBanner(Long chatRoomId) {
 
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)

--- a/src/main/java/com/umc/yeongkkeul/web/dto/BannerResponseDto.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/BannerResponseDto.java
@@ -1,6 +1,8 @@
 package com.umc.yeongkkeul.web.dto;
 
 import com.umc.yeongkkeul.domain.ChatRoom;
+import com.umc.yeongkkeul.domain.enums.AgeGroup;
+import com.umc.yeongkkeul.domain.enums.Job;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -23,7 +25,7 @@ public class BannerResponseDto {
                 .avgAmount(chatRoom.getAverageExpense())
                 .age(chatRoom.getAgeGroupFilter().getAgeGroup())
                 .job(chatRoom.getJobFilter().getJob())
-                .topRate((chatRoom.getAgeGroupFilter().equals("UNDECIDED")&&chatRoom.getJobFilter().equals("UNDECIDED")) ? null : chatRoom.getRanking())
+                .topRate((chatRoom.getAgeGroupFilter()==AgeGroup.UNDECIDED && chatRoom.getJobFilter()==Job.UNDECIDED) ? null : chatRoom.getRanking())
                 .createdAt(createdAt)
                 .build();
     }

--- a/src/main/java/com/umc/yeongkkeul/web/dto/BannerResponseDto.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/BannerResponseDto.java
@@ -1,5 +1,6 @@
 package com.umc.yeongkkeul.web.dto;
 
+import com.umc.yeongkkeul.domain.ChatRoom;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,11 +8,23 @@ import lombok.Getter;
 @Builder
 public class BannerResponseDto {
 
-    private int achievingCount;
-    private int chatRoomUserCount;
-    private int avgAmount;
-    private String age;
-    private String job;
-    private Double topRate;
-    private String createdAt;
+    private Integer achievingCount; // 목표 달성 챌린저 수
+    private Integer chatRoomUserCount; // 채팅방 내 챌린저 수
+    private Integer avgAmount; // 채팅방의 지출 평균
+    private String age; // 나이대
+    private String job; // 직업대
+    private Double topRate; // 상위 백분위
+    private String createdAt; // 공지 날짜
+
+    public static BannerResponseDto from(ChatRoom chatRoom, String createdAt) {
+        return BannerResponseDto.builder()
+                .achievingCount(chatRoom.getAchievedCount())
+                .chatRoomUserCount(chatRoom.getParticipationCount())
+                .avgAmount(chatRoom.getAverageExpense())
+                .age(chatRoom.getAgeGroupFilter().getAgeGroup())
+                .job(chatRoom.getJobFilter().getJob())
+                .topRate((chatRoom.getAgeGroupFilter().equals("UNDECIDED")&&chatRoom.getJobFilter().equals("UNDECIDED")) ? null : chatRoom.getRanking())
+                .createdAt(createdAt)
+                .build();
+    }
 }

--- a/src/main/java/com/umc/yeongkkeul/web/dto/BannerResponseDto.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/BannerResponseDto.java
@@ -15,7 +15,7 @@ public class BannerResponseDto {
     private Integer avgAmount; // 채팅방의 지출 평균
     private String age; // 나이대
     private String job; // 직업대
-    private Double topRate; // 상위 백분위
+    private Integer topRate; // 상위 백분위
     private String createdAt; // 공지 날짜
 
     public static BannerResponseDto from(ChatRoom chatRoom, String createdAt) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#120

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- ChatRoom엔티티에 achievedCount(목표 달성 인원), averageExpense(챌린저 지출 평균), ranking(채팅방 백분위) 컬럼 추가
- 추가한 엔티티 관련 데이터 스프링 배치 작업
  - ranking은 정책상 채팅방 인원 5명 이상일 때만 집계되기 때문에 5명 이하인 경우 null 처리
  - 나이대, 직업 설정 -> 설정된 필터 채팅방 내 순위
  - 나이대, 직업 설정 x -> 전체 채팅방 내 순위
- 배치된 데이터 바탕으로 채팅방 배너 조회 api 로직 수정 

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
테스트는 완료했으나, 쿼리 정리(최적화)가 필요해 리팩토링 예정 