### PR TITLE
feat: 채팅방 이미지 업로드 이후, 채팅방 전송로직 추가

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/service/ChatService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ChatService.java
@@ -596,9 +596,23 @@ public class ChatService {
                         .build())
                 .forEach(message -> {
                     sendMessage(message); // 메시지 전송
-                    log.info("Send a message to chat room ID: {}", message.chatRoomId());
+                    log.info("Send a receipt message to chat room ID: {}", message.chatRoomId());
                     saveMessages(message); // 메시지 저장
                 });
+    }
+
+    public void sendImageChat(Long userId, Long chatRoomId, String imageUrl){
+        MessageDto message = MessageDto.builder()
+                .id(TsidCreator.getTsid().toLong()) // TSID ID 생성기, 시간에 따라 ID에 영향이 가고 최신 데이터일수록 ID 값이 커진다.
+                .chatRoomId(chatRoomId)
+                .senderId(userId)
+                .messageType("IMAGE")
+                .content(imageUrl)
+                .timestamp(LocalDateTime.now().toString())
+                .build();
+        sendMessage(message); // 메시지 전송
+        log.info("Send a image message to chat room ID: {}", message.chatRoomId());
+        saveMessages(message); // 메시지 저장
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
@@ -180,13 +180,14 @@ public class ChatAPIController {
      * @return S3에 저장된 이미지 URL
      */
     @PostMapping(value = "/{chatRoomId}/images", consumes = "multipart/form-data")
-    @Operation(summary = "채팅 이미지 업로드", description = "채팅 이미지를 S3에 업로드하고 이미지 URL을 반환합니다.")
-    public ApiResponse<String> uploadChatImage(@RequestBody ImageChatRequestDTO.ImageDTO request,
+    @Operation(summary = "채팅 이미지 업로드 & 전송", description = "채팅 이미지를 S3에 업로드하고 url을 채팅으로 전송합니다.")
+    public ApiResponse<String> sendChatImage(@RequestBody ImageChatRequestDTO.ImageDTO request,
                                                @PathVariable Long chatRoomId
                                                ) {
         Long userId = toId(getCurrentUserId());
         String imageUrl = chatService.uploadChatImage(userId,chatRoomId, request.getChatPicture());
-        return ApiResponse.onSuccess(imageUrl);
+        chatService.sendImageChat(userId, chatRoomId, imageUrl);
+        return ApiResponse.onSuccess(imageUrl); // 전송된 이미지 url 리턴
     }
 
     // FIXME: ENUM 상수 값을 적적한 한글로 변환하는 로직이 필요.


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#136 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 채팅방 이미지 업로드 이후, 채팅방 전송로직 추가
- 기존에는 이미지를 업로드한 뒤 이미지 URL만 반환하는 방식이었습니다. 이번에 메시지 전송 로직(sendImageChat)을 함께 추가하여, 이미지가 업로드되면 해당 이미지를 자동으로 채팅방에 전송하도록 구현하였습니다. 이를 통해 사용자는 업로드된 이미지를 별도의 추가 액션 없이 바로 채팅 내에서 확인할 수 있으며, 프론트엔드에서는 “서랍 기능”에만 집중할 수 있도록 개선하였습니다.

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->