### PR TITLE
feat: 로그인시 해당 유저의 userId 추가로 리턴하도록 로직 변경

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/repository/UserRepository.java
+++ b/src/main/java/com/umc/yeongkkeul/repository/UserRepository.java
@@ -28,4 +28,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u WHERE u.id IN :userIds ORDER BY u.nickname")
     List<User> findAllByIdInOrderByNickname(List<Long> userIds);
+
+    Optional<User> findByOauthTypeAndEmail(String oauthType, String email);
 }

--- a/src/main/java/com/umc/yeongkkeul/service/GoogleLoginService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/GoogleLoginService.java
@@ -72,6 +72,7 @@ public class GoogleLoginService {
                             .email(googleInfoResponseDto.getEmail())
                             .nickname(googleInfoResponseDto.getName())
                             .gender("UNDECIDED")
+                            .rewardBalance(0)
                             .build();
                     // 새로 생성 후 DB 저장
                     return userRepository.save(newUser);

--- a/src/main/java/com/umc/yeongkkeul/service/KakaoLoginService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/KakaoLoginService.java
@@ -174,6 +174,7 @@ public class KakaoLoginService {
                             .email(email)
                             .nickname(name)
                             .gender("UNDECIDED")
+                            .rewardBalance(0)
                             .build();
                     return userRepository.save(newUser);
                 });

--- a/src/main/java/com/umc/yeongkkeul/service/KakaoLoginService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/KakaoLoginService.java
@@ -158,35 +158,34 @@ public class KakaoLoginService {
     //카카오 로그인 성공 기본 값 저장
     public SocialInfoResponseDto.KakaoInfoDTO loginUserInfo(String jwtToken, String refreshToken, String email, String name){
 
-        boolean isExistUser = userRepository.existsByEmail(email);
         boolean isExistTerms = userTermsRepository.existsByUser_EmailAndUser_OauthType(email,"KAKAO");
 
         String redirectUrl = isExistTerms ? "/api/home" : "/api/auth/user-info";
 
         //초기 사용자 값 저장(kakao 정보)
-        if(!isExistUser){
-            User user = User.builder()
-                    .nickname(name)
-                    .email(email)
-                    .job(Job.UNDECIDED)
-                    .userRole(UserRole.USER)
-                    .oauthType("KAKAO")
-                    .referralCode(generateRandomCode(6))
-                    .oauthKey(refreshToken)
-                    .gender("UNDECIDED")
+        User user = userRepository.findByOauthTypeAndEmail("KAKAO", email)
+                .orElseGet(() -> {
+                    User newUser = User.builder()
+                            .oauthType("KAKAO")
+                            .oauthKey(refreshToken)
+                            .job(Job.UNDECIDED)
+                            .ageGroup(AgeGroup.UNDECIDED)
+                            .referralCode(generateRandomCode(6))
+                            .email(email)
+                            .nickname(name)
+                            .gender("UNDECIDED")
+                            .build();
+                    return userRepository.save(newUser);
+                });
 
-                    .ageGroup(AgeGroup.UNDECIDED)
-                    .rewardBalance(0)
-                    .build();
-
-            userRepository.save(user);
-        }
+        user.setOauthKey(refreshToken);
 
         return SocialInfoResponseDto.KakaoInfoDTO.builder()
                 .accessToken(jwtToken)
                 .refreshToken(refreshToken)
                 .email(email)
                 .redirectUrl(redirectUrl)
+                .userId(user.getId())
                 .build();
     }
 

--- a/src/main/java/com/umc/yeongkkeul/web/dto/SocialInfoResponseDto.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/SocialInfoResponseDto.java
@@ -17,7 +17,7 @@ public class SocialInfoResponseDto {
         String refreshToken;
         String email;
         String redirectUrl;
-
+        Long userId;
     }
 
     @Builder
@@ -30,6 +30,7 @@ public class SocialInfoResponseDto {
         String refreshToken;
         String email;
         String redirectUrl;
+        Long userId;
     }
 
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#140 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 로그인 시, 해당 유저의 userId값도 리턴하도록 dto 추가 및 서비스 로직 변경
- 기존 유저의 경우도 refreshToekn을 업데이트해서, 재발급 이슈에 대해서 정상적으로 돌아가도록 변경

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
기존 로그인 로직과 비교해서, 변경사항 있는 지 점검 부탁드립니다.
