### PR TITLE
fix: 카테고리가 지니고 있는 expenseList 필드를 빌더에서 초기화 보장하도록 Default 지정

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/domain/Category.java
+++ b/src/main/java/com/umc/yeongkkeul/domain/Category.java
@@ -46,6 +46,7 @@ public class Category extends BaseEntity {
     @JsonManagedReference
     private User user;
 
+    @Builder.Default
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
     private List<Expense> expenseList = new ArrayList<>();
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#163 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- Category 엔티티의 expenseList에 @Builder.Default를 추가하여 컬렉션 필드 기본값을 new ArrayList<>()로 설정.

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
