### PR TITLE
feat: 카테고리 n일 연속 무지출 달성 리워드 지급

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/domain/Category.java
+++ b/src/main/java/com/umc/yeongkkeul/domain/Category.java
@@ -41,6 +41,9 @@ public class Category extends BaseEntity {
     @Column(name = "blue", nullable = false)
     private int blue;
 
+    @Column(name = "consecutive_no_spending_days")
+    private int consecutiveNoSpendingDays;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     @JsonManagedReference

--- a/src/main/java/com/umc/yeongkkeul/domain/User.java
+++ b/src/main/java/com/umc/yeongkkeul/domain/User.java
@@ -137,4 +137,9 @@ public class User extends BaseEntity {
     public AgeGroup getAge() {
         return ageGroup;
     }
+
+    public void addReward(Reward reward) {
+        this.rewardList.add(reward);
+        reward.setUser(this);
+    }
 }

--- a/src/main/java/com/umc/yeongkkeul/repository/ExpenseRepository.java
+++ b/src/main/java/com/umc/yeongkkeul/repository/ExpenseRepository.java
@@ -24,4 +24,18 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     @Query("SELECT e FROM Expense e WHERE e.user.id = :userId AND e.day = :yesterday")
     List<Expense> findYesterdayExpenseByUserId(@Param("userId") Long userId, @Param("yesterday") LocalDate yesterday);
+
+    @Query("""
+        SELECT CASE WHEN COUNT(e) > 0 THEN true ELSE false END
+        FROM Expense e
+        WHERE e.user.id = :userId
+          AND e.category.id = :categoryId
+          AND e.day = :day
+          AND e.isNoSpending = true
+    """)
+    boolean existsNoSpendingExpense(
+            @Param("userId") Long userId,
+            @Param("categoryId") Long categoryId,
+            @Param("day") LocalDate day
+    );
 }

--- a/src/main/java/com/umc/yeongkkeul/repository/ExpenseRepository.java
+++ b/src/main/java/com/umc/yeongkkeul/repository/ExpenseRepository.java
@@ -38,4 +38,7 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
             @Param("categoryId") Long categoryId,
             @Param("day") LocalDate day
     );
+
+    // 특정 유저가 특정 날짜에 가지고 있는 지출(무지출 포함) 레코드 개수를 반환
+    long countByUserAndDay(User user, LocalDate day);
 }

--- a/src/main/java/com/umc/yeongkkeul/service/ExpenseCommandServiceImpl.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ExpenseCommandServiceImpl.java
@@ -8,12 +8,11 @@ import com.umc.yeongkkeul.aws.s3.AmazonS3Manager;
 import com.umc.yeongkkeul.converter.ExpenseConverter;
 import com.umc.yeongkkeul.domain.Category;
 import com.umc.yeongkkeul.domain.Expense;
+import com.umc.yeongkkeul.domain.Reward;
 import com.umc.yeongkkeul.domain.User;
 import com.umc.yeongkkeul.domain.common.Uuid;
-import com.umc.yeongkkeul.repository.CategoryRepository;
-import com.umc.yeongkkeul.repository.ExpenseRepository;
-import com.umc.yeongkkeul.repository.UserRepository;
-import com.umc.yeongkkeul.repository.UuidRepository;
+import com.umc.yeongkkeul.domain.enums.RewardType;
+import com.umc.yeongkkeul.repository.*;
 import com.umc.yeongkkeul.web.dto.ExpenseRequestDTO;
 import com.umc.yeongkkeul.web.dto.MyPageInfoResponseDto;
 import com.umc.yeongkkeul.web.dto.NotificationDetailRequestDto;
@@ -37,6 +36,7 @@ public class ExpenseCommandServiceImpl extends ExpenseCommandService {
     private final UuidRepository uuidRepository;
     private final AmazonS3Manager amazonS3Manager;
     private final NotificationService notificationService;
+    private final RewardRepository rewardRepository;
 
     // 유저의 지출 내역 생성
     @Override
@@ -222,7 +222,21 @@ public class ExpenseCommandServiceImpl extends ExpenseCommandService {
             // 보상 로직: 10×k
             int reward = 10 * k;
             user.setRewardBalance(user.getRewardBalance() + reward);
-            userRepository.save(user);
+
+
+
+            Reward rewardRecord = Reward.builder()
+                    .amount(reward)
+                    .rewardType(RewardType.INDIVIDUAL)
+                    .description(consecutiveDays + "일 연속 무지출 달성 보상")
+                    .user(user)
+                    .build();
+
+            user.addReward(rewardRecord);
+
+            rewardRepository.save(rewardRecord);
+
+
 
             // 알림
             notificationService.createNotification(


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#166 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 무지출을 추적해서 포인트 추가하고, 알림 날리기!
- 하루에 하나 이상의 무지출/지출 기록이 있을 경우, 추가 무지출 입력 시 연속 무지출 일수를 증가시키지 않도록 수정
  - `ExpenseRepository`에 `countByUserAndDay(user, currentDay)` 메서드 추가
  - `updateConsecutiveNoSpendingDays()` 내에서 오늘 이미 지출(무지출 포함) 기록이 있으면 연속 무지출 로직 무시
- 기존 어제 무지출 확인 로직(`existsNoSpendingExpense`)은 그대로 유지
- 리워드 내역 추가
- 리워드 유저 잔액 반영

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
