### PR TITLE
[FEAT] 하루 목표 지출액 초과 알림 생성

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/domain/User.java
+++ b/src/main/java/com/umc/yeongkkeul/domain/User.java
@@ -83,9 +83,11 @@ public class User extends BaseEntity {
     private boolean notificationAgreed;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @JsonBackReference
     private List<Reward> rewardList = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @JsonBackReference
     private List<ChatRoomMembership> chatRoomMembershipList = new ArrayList<>();
 
     /*

--- a/src/main/java/com/umc/yeongkkeul/repository/ExpenseRepository.java
+++ b/src/main/java/com/umc/yeongkkeul/repository/ExpenseRepository.java
@@ -41,4 +41,8 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
 
     // 특정 유저가 특정 날짜에 가지고 있는 지출(무지출 포함) 레코드 개수를 반환
     long countByUserAndDay(User user, LocalDate day);
+
+    // 오늘 하루에 해당되는 지출
+    @Query("SELECT e FROM Expense e WHERE e.user.id = :userId AND e.day = :today")
+    List<Expense> findByUserIdAndExpenseDayToday(@Param("userId") Long userId, @Param("today") LocalDate today);
 }

--- a/src/main/java/com/umc/yeongkkeul/service/NotificationService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/NotificationService.java
@@ -4,13 +4,16 @@ import com.umc.yeongkkeul.apiPayload.code.status.ErrorStatus;
 import com.umc.yeongkkeul.apiPayload.exception.handler.NotificationReadHandler;
 import com.umc.yeongkkeul.apiPayload.exception.handler.UserHandler;
 import com.umc.yeongkkeul.converter.NotificationConverter;
+import com.umc.yeongkkeul.domain.Expense;
 import com.umc.yeongkkeul.domain.Notification;
 import com.umc.yeongkkeul.domain.User;
 import com.umc.yeongkkeul.domain.enums.NotificationType;
 import com.umc.yeongkkeul.domain.mapping.NotificationRead;
+import com.umc.yeongkkeul.repository.ExpenseRepository;
 import com.umc.yeongkkeul.repository.NotificationReadRepository;
 import com.umc.yeongkkeul.repository.NotificationRepository;
 import com.umc.yeongkkeul.repository.UserRepository;
+import com.umc.yeongkkeul.web.dto.ExpenseRequestDTO;
 import com.umc.yeongkkeul.web.dto.NotificationAgreedRequestDto;
 import com.umc.yeongkkeul.web.dto.NotificationDetailRequestDto;
 import com.umc.yeongkkeul.web.dto.NotificationDetailsResponseDto;
@@ -22,6 +25,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,6 +37,7 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final NotificationReadRepository notificationReadRepository;
     private final UserRepository userRepository;
+    private final ExpenseRepository expenseRepository;
 
     private final int NOTIFICATION_PAGING_SIZE = 30; // 한 페이지 당 최대 30개를 조회
 
@@ -135,5 +140,37 @@ public class NotificationService {
     public Integer raedAllNotifications(Long userId) {
 
         return notificationReadRepository.setNotificationUnreadToRead(userId);
+    }
+
+    @Transactional
+    public void spendingNotification(Long userId, LocalDate expenseday){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus._USER_NOT_FOUND));
+
+        // 사용자 하루 목표 지출액이 설정되어 있지 않다면 로직 종료
+        if (user.getDayTargetExpenditure() == null) {
+            return;
+        }
+
+        // 오늘 날짜와 일치하지 않는 경우, 로직 종료
+        if (!expenseday.equals(LocalDate.now())) {
+            return;
+        }
+
+        List<Expense> expenditures = expenseRepository.findByUserIdAndExpenseDayToday(userId, expenseday);
+
+        int totalSpending = expenditures.stream().mapToInt(Expense::getAmount).sum();
+
+        // 오늘 사용한 총 지출액 > 하루 목표 지출액 인 경우
+        if (totalSpending > user.getDayTargetExpenditure()) {
+            createNotification(
+                    user.getId(),
+                    new NotificationDetailRequestDto(
+                            "EXCEED_DAILY_SPENDING_GOAL",
+                            "하루 목표 지출액 초과",
+                            null
+                    )
+            );
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#174 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 지출 생성 또는 수정 - 하루 목표 지출액 초과 알림 생성
- 초과되는 처음에만 알림이 생성되도록 함
- 하루 목표 지출액이 설정되어 있지 않은 유저라면 알림 생성 X
- 해당 지출 기록의 날짜가 오늘이 아닌 경우 알림 생성 X

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
