### PR TITLE
fix: 카테고리 각각 적용하도록 로직 변경

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/repository/ExpenseRepository.java
+++ b/src/main/java/com/umc/yeongkkeul/repository/ExpenseRepository.java
@@ -1,5 +1,6 @@
 package com.umc.yeongkkeul.repository;
 
+import com.umc.yeongkkeul.domain.Category;
 import com.umc.yeongkkeul.domain.Expense;
 import com.umc.yeongkkeul.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,6 +26,9 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
     @Query("SELECT e FROM Expense e WHERE e.user.id = :userId AND e.day = :yesterday")
     List<Expense> findYesterdayExpenseByUserId(@Param("userId") Long userId, @Param("yesterday") LocalDate yesterday);
 
+    // 특정 유저의 특정 카테고리 + 특정 일자에 존재하는 모든 Expense 개수를 카운트
+    long countByUserAndCategoryAndDay(User user, Category category, LocalDate day);
+
     @Query("""
         SELECT CASE WHEN COUNT(e) > 0 THEN true ELSE false END
         FROM Expense e
@@ -33,12 +37,5 @@ public interface ExpenseRepository extends JpaRepository<Expense, Long> {
           AND e.day = :day
           AND e.isNoSpending = true
     """)
-    boolean existsNoSpendingExpense(
-            @Param("userId") Long userId,
-            @Param("categoryId") Long categoryId,
-            @Param("day") LocalDate day
-    );
-
-    // 특정 유저가 특정 날짜에 가지고 있는 지출(무지출 포함) 레코드 개수를 반환
-    long countByUserAndDay(User user, LocalDate day);
+    boolean existsNoSpendingExpense(Long userId, Long categoryId, LocalDate day);
 }

--- a/src/main/java/com/umc/yeongkkeul/service/ExpenseCommandServiceImpl.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ExpenseCommandServiceImpl.java
@@ -188,7 +188,7 @@ public class ExpenseCommandServiceImpl extends ExpenseCommandService {
         LocalDate currentDay = expense.getDay();
 
         // 오늘 다른 지출(무지출)이 있는지 점검. 만약 있다면 -> 이는 사용자의 악용 방지, 현재 것도 포함이므로 1개 초과시 이미 존재!
-        long countToday = expenseRepository.countByUserAndDay(user, currentDay);
+        long countToday = expenseRepository.countByUserAndCategoryAndDay(user, category, currentDay);
 
         if (countToday > 1) {
             // 이미 오늘 해당 유저가 어떤 지출(혹은 무지출) 기록을 가지고 있음


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#166 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 무지출 추적 로직을 카테고리 각각 적용하도록 변경

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
