### PR TITLE
fix: 이미지 업로드 reqBody 대신 reqParam으로 변경

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
@@ -181,11 +181,11 @@ public class ChatAPIController {
      */
     @PostMapping(value = "/{chatRoomId}/images", consumes = "multipart/form-data")
     @Operation(summary = "채팅 이미지 업로드 & 전송", description = "채팅 이미지를 S3에 업로드하고 url을 채팅으로 전송합니다.")
-    public ApiResponse<String> sendChatImage(@RequestBody ImageChatRequestDTO.ImageDTO request,
-                                               @PathVariable Long chatRoomId
+    public ApiResponse<String> sendChatImage(@PathVariable Long chatRoomId,
+                                             @RequestParam("chatPicture") MultipartFile chatPicture
                                                ) {
         Long userId = toId(getCurrentUserId());
-        String imageUrl = chatService.uploadChatImage(userId,chatRoomId, request.getChatPicture());
+        String imageUrl = chatService.uploadChatImage(userId,chatRoomId, chatPicture);
         chatService.sendImageChat(userId, chatRoomId, imageUrl);
         return ApiResponse.onSuccess(imageUrl); // 전송된 이미지 url 리턴
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#136 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 이미지 업로드 reqBody 대신 reqParam으로 변경

@RequestBody는 요청 내용을 객체로 바인딩하기 위함. 이미지가 포함되는 경우 사용하면  415의 지원되지 않은 파일형식 에러를 발생시키게 됨. 따라서 파일만 필요한 경우는 @RequestParam을 사용하고, 미디어파일 외의 복합적인 데이터가 필요하면 @RequestPart를 사용해야함. 굳이 DTO를 통해서 함께 묶고 싶다면, ReqBody가 아니라 @ModelAttribute를 사용해야함.

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
