### PR TITLE
fix: 채팅방 이미지 다운로드 수정 및 이미지 채팅 조회 리턴값 id 추가

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/service/ChatService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ChatService.java
@@ -563,11 +563,15 @@ public class ChatService {
      * 이미지 메시지 URL 리스트를 반환
      * messageType이 "IMAGE"인 경우, content에 저장된 S3 key를 이용해 URL을 생성
      */
-    public List<String> getChatRoomImageUrls(Long chatRoomId) {
+    public List<ImageChatResponseDTO> getChatRoomImageUrls(Long chatRoomId) {
         List<MessageDto> messages = getMessages(chatRoomId);
+
         return messages.stream()
                 .filter(m -> "IMAGE".equalsIgnoreCase(m.messageType()))
-                .map(m -> amazonS3Manager.getFileUrl(m.content()))
+                .map(m -> new ImageChatResponseDTO(
+                        m.id(),                              // 메시지 ID
+                        amazonS3Manager.getFileUrl(m.content())  // S3에 있는 실제 이미지 URL
+                ))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
+++ b/src/main/java/com/umc/yeongkkeul/web/controller/ChatAPIController.java
@@ -134,8 +134,8 @@ public class ChatAPIController {
      */
     @GetMapping("/{chatRoomId}/images")
     @Operation(summary = "채팅방 이미지 조회", description = "채팅방에 업로드된 이미지 목록(이미지 URL)을 조회합니다.")
-    public ApiResponse<List<String>> getChatRoomImages(@PathVariable Long chatRoomId) {
-        List<String> imageUrls = chatService.getChatRoomImageUrls(chatRoomId);
+    public ApiResponse<List<ImageChatResponseDTO>> getChatRoomImages(@PathVariable Long chatRoomId) {
+        List<ImageChatResponseDTO> imageUrls = chatService.getChatRoomImageUrls(chatRoomId);
         return ApiResponse.onSuccess(imageUrls);
     }
 

--- a/src/main/java/com/umc/yeongkkeul/web/dto/chat/ImageChatResponseDTO.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/chat/ImageChatResponseDTO.java
@@ -1,0 +1,13 @@
+package com.umc.yeongkkeul.web.dto.chat;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ImageChatResponseDTO {
+    private Long messageId;
+    private String imageUrl;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#181 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 채팅방 이미지 다운로드시, 이미지 url을 파싱해서 key로 변환해서 사용하도록 로직 수정
- 채팅방 내 이미지 조회시, id값 추가

## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
