### PR TITLE
fix: 채팅방 메시지 id값 불일치 현상 직렬화 문제 해결

### DIFF
--- a/src/main/java/com/umc/yeongkkeul/service/ChatService.java
+++ b/src/main/java/com/umc/yeongkkeul/service/ChatService.java
@@ -584,7 +584,10 @@ public class ChatService {
     @Transactional(readOnly = true)
     public AmazonS3Manager.S3DownloadResponse downloadChatImage(Long chatRoomId, Long messageId) {
         Optional<MessageDto> optionalImageMessage = getMessages(chatRoomId).stream()
-                .filter(m -> m.id().equals(messageId) && "IMAGE".equalsIgnoreCase(m.messageType()))
+                .filter(m -> {
+                    System.out.println("Comparing: m.id()=" + m.id() + " (" + m.id().getClass() + ") vs messageId=" + messageId + " (" + messageId.getClass() + ")");
+                    return m.id().equals(messageId) && "IMAGE".equalsIgnoreCase(m.messageType());
+                })
                 .findFirst();
         if (optionalImageMessage.isEmpty()) {
             throw new ChatRoomHandler(ErrorStatus._CHAT_IMAGE_NOT_FOUND);

--- a/src/main/java/com/umc/yeongkkeul/web/dto/chat/MessageDto.java
+++ b/src/main/java/com/umc/yeongkkeul/web/dto/chat/MessageDto.java
@@ -1,5 +1,7 @@
 package com.umc.yeongkkeul.web.dto.chat;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -10,6 +12,7 @@ import java.time.LocalDateTime;
  */
 @Builder
 public record MessageDto(
+        @JsonSerialize(using = ToStringSerializer.class) // Long을 String으로 직렬화 Long으로 진행시 서버 내부 로직은 괜찮지만 프론트 소통과정에서 유실 발생.
         Long id, // 메시지 ID
         Long chatRoomId, // 목적지(전달할 그룹 채팅방) ID
         Long senderId, // 발신인 ID


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#182 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요 -->
- 채팅방 메시지 id값 불일치 현상 직렬화 문제 해결
- 다운로드 로직 보강 (버그는 없었음)

Comparing: m.id()=680121464358249748 (class java.lang.Long) vs messageId=680121464358249700 (class java.lang.Long)
위 값 중 프론트에서 api를 통해 조회했던 값인 우측 값이 정확도 문제로 값이 유실된 점을 확인할 수 있음. 키값이 크기 때문에 변형가능성이 있어 Json 직렬화 과정 중 String으로 변경했음.



## 스크린샷 
<!-- 실행 결과를 첨부해 주세요 -->

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
